### PR TITLE
Fixed decontainer build with poetry and docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,18 +1,13 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/python:3.11-bookworm",
-  "postCreateCommand": "pip3 install -r legacy_app/requirements.txt && pip3 install -r requirements.dev.txt && sudo apt-get update && sudo apt-get install libgl-dev libmagic-dev  -y",
+  "image": "ubuntu:latest",
+  "postCreateCommand": "pip3 install poetry && sudo apt-get update && apt-get install libgl-dev libmagic-dev docker.io  -y && poetry install && chmod 777 data/elastic",
   "name": "redbox-dev",
   "features": {
-    "ghcr.io/devcontainers/features/aws-cli:1": {},
     "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/terraform:1": {},
     "ghcr.io/devcontainers-contrib/features/black:2": {},
     "ghcr.io/devcontainers-contrib/features/isort:2": {},
-    "ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},
     "ghcr.io/jungaretti/features/make:1": {},
-    "ghcr.io/joshuanianji/devcontainer-features/aws-cli-persistence:1.0.1": {},
-    "ghcr.io/joshuanianji/devcontainer-features/aws-cli-persistence:1": {},
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
   "runArgs": [
@@ -20,6 +15,9 @@
     "host" // use host networking so that the dev container can access the API when running the container locally
   ],
   "forwardPorts": [
-    8501 // port for streamlit
+    8501,
+    5601,
+    9200,
+    9001
   ]
 }


### PR DESCRIPTION
## Context

Devcontainer was out of date and had no docker

## Changes proposed in this pull request

Changed to Ubuntu base image, poetry install and docker installed.

## Guidance to review

Click open Github Code Space

## Relevant links


## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
