### PR TITLE
REDBOX 76: Adds File status updates to core-api upload

### DIFF
--- a/core_api/tests/conftest.py
+++ b/core_api/tests/conftest.py
@@ -1,12 +1,13 @@
 import os
-from typing import TypeVar, Generator
+from typing import Generator, TypeVar
 
 import pytest
 from elasticsearch import Elasticsearch
-
 from fastapi.testclient import TestClient
-from redbox.models import File
-from core_api.src.app import app as application, env
+
+from core_api.src.app import app as application
+from core_api.src.app import env
+from redbox.models import File, ProcessingStatusEnum
 from redbox.storage import ElasticsearchStorageHandler
 
 T = TypeVar("T")
@@ -66,6 +67,7 @@ def file(s3_client, file_pdf_path, bucket) -> YieldFixture[File]:
         type=file_type,
         creator_user_uuid="dev",
         storage_kind=env.object_store,
+        processing_status=ProcessingStatusEnum.uploaded,
     )
 
     yield file_record
@@ -89,7 +91,9 @@ def bucket(s3_client):
 def file_pdf_path() -> YieldFixture[str]:
     path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
-        "..", "..", "tests",
+        "..",
+        "..",
+        "tests",
         "data",
         "pdf",
         "Cabinet Office - Wikipedia.pdf",

--- a/core_api/tests/test_app.py
+++ b/core_api/tests/test_app.py
@@ -4,6 +4,7 @@ import pytest
 from elasticsearch import NotFoundError
 
 from core_api.src.app import env
+from redbox.models import ProcessingStatusEnum
 
 
 def test_get_health(app_client):
@@ -16,7 +17,9 @@ def test_get_health(app_client):
     assert response.status_code == 200
 
 
-def test_post_file_upload(s3_client, app_client, elasticsearch_storage_handler, bucket, file_pdf_path):
+def test_post_file_upload(
+    s3_client, app_client, elasticsearch_storage_handler, bucket, file_pdf_path
+):
     """
     Given a new file
     When I POST it to /file
@@ -27,8 +30,12 @@ def test_post_file_upload(s3_client, app_client, elasticsearch_storage_handler, 
     assert response.status_code == 200
     assert s3_client.get_object(Bucket=bucket, Key=file_pdf_path.split("/")[-1])
     json_response = response.json()
-    assert elasticsearch_storage_handler.read_item(
-        item_uuid=json_response["uuid"], model_type=json_response["model_type"]
+    assert (
+        elasticsearch_storage_handler.read_item(
+            item_uuid=json_response["uuid"],
+            model_type=json_response["model_type"],
+        ).processing_status
+        is ProcessingStatusEnum.parsing
     )
 
 
@@ -43,7 +50,9 @@ def test_get_file(app_client, stored_file):
     assert response.status_code == 200
 
 
-def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, bucket, stored_file):
+def test_delete_file(
+    s3_client, app_client, elasticsearch_storage_handler, bucket, stored_file
+):
     """
     Given a previously saved file
     When I DELETE it to /file
@@ -51,7 +60,9 @@ def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, bucke
     """
     # check assets exist
     assert s3_client.get_object(Bucket=bucket, Key=stored_file.name)
-    assert elasticsearch_storage_handler.read_item(item_uuid=stored_file.uuid, model_type="file")
+    assert elasticsearch_storage_handler.read_item(
+        item_uuid=stored_file.uuid, model_type="file"
+    )
 
     response = app_client.delete(f"/file/{stored_file.uuid}")
     assert response.status_code == 200
@@ -61,10 +72,14 @@ def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, bucke
         s3_client.get_object(Bucket=bucket, Key=stored_file.name)
 
     with pytest.raises(NotFoundError):
-        elasticsearch_storage_handler.read_item(item_uuid=stored_file.uuid, model_type="file")
+        elasticsearch_storage_handler.read_item(
+            item_uuid=stored_file.uuid, model_type="file"
+        )
 
 
-def test_ingest_file(app_client, rabbitmq_channel, stored_file):
+def test_ingest_file(
+    app_client, rabbitmq_channel, stored_file, elasticsearch_storage_handler
+):
     """
     Given a previously saved file
     When I POST to /file/uuid/ingest
@@ -76,9 +91,19 @@ def test_ingest_file(app_client, rabbitmq_channel, stored_file):
         message_consumed.set()
         ch.basic_ack(delivery_tag=method.delivery_tag)
 
-    rabbitmq_channel.basic_consume(queue=env.ingest_queue_name, on_message_callback=callback)
+    rabbitmq_channel.basic_consume(
+        queue=env.ingest_queue_name, on_message_callback=callback
+    )
 
     response = app_client.post(f"/file/{stored_file.uuid}/ingest/")
+
+    assert (
+        elasticsearch_storage_handler.read_item(
+            item_uuid=stored_file.uuid,
+            model_type="file",
+        ).processing_status
+        is ProcessingStatusEnum.parsing
+    )
     assert response.status_code == 200
 
     # TODO: fix this!

--- a/docs/prod-architecture.md
+++ b/docs/prod-architecture.md
@@ -7,11 +7,11 @@ flowchart TB;
 
     subgraph core-api[Core API]
         subgraph file["/file"]
-            file-upload["/file/upload"]
-            file-ingest["/file/ingest"]
-            file-delete["/file/delete"]
-            file-search["/file/search"]
-            file-chunks["/file/chunks"]
+            file-upload[POST "/file"]
+            file-ingest[POST "/file/{file_uuid}/ingest"]
+            file-delete[DELETE "/file/{file_uuid}"]
+            file-search[POST "/file/{file_uuid}/search"]
+            file-chunks[GET "/file/{file_uuid}chunks"]
         end
 
         subgraph chat["/chat"]

--- a/docs/prod-architecture.md
+++ b/docs/prod-architecture.md
@@ -7,11 +7,11 @@ flowchart TB;
 
     subgraph core-api[Core API]
         subgraph file["/file"]
-            file-upload[POST "/file"]
-            file-ingest[POST "/file/{file_uuid}/ingest"]
-            file-delete[DELETE "/file/{file_uuid}"]
-            file-search[POST "/file/{file_uuid}/search"]
-            file-chunks[GET "/file/{file_uuid}chunks"]
+            file-upload["/file"]
+            file-ingest["/file/{file_uuid}/ingest"]
+            file-delete["/file/{file_uuid}"]
+            file-search["/file/{file_uuid}/search"]
+            file-chunks["/file/{file_uuid}/chunks"]
         end
 
         subgraph chat["/chat"]

--- a/redbox/models/__init__.py
+++ b/redbox/models/__init__.py
@@ -1,21 +1,10 @@
 from redbox.models.chat import ChatMessage
 from redbox.models.collection import Collection
 from redbox.models.feedback import Feedback
-from redbox.models.file import Chunk, File
-from redbox.models.spotlight import (
-    Spotlight,
-    SpotlightComplete,
-    SpotlightTask,
-    SpotlightTaskComplete,
-)
+from redbox.models.file import Chunk, File, ProcessingStatusEnum
+from redbox.models.llm import EmbeddingResponse, EmbedQueueItem, ModelInfo, ModelListResponse, StatusResponse
 from redbox.models.settings import Settings
-from redbox.models.llm import (
-    ModelInfo,
-    ModelListResponse,
-    EmbeddingResponse,
-    EmbedQueueItem,
-    StatusResponse,
-)
+from redbox.models.spotlight import Spotlight, SpotlightComplete, SpotlightTask, SpotlightTaskComplete
 
 __all__ = [
     "ChatMessage",
@@ -33,4 +22,5 @@ __all__ = [
     "EmbeddingResponse",
     "EmbedQueueItem",
     "StatusResponse",
+    "ProcessingStatusEnum",
 ]

--- a/redbox/models/file.py
+++ b/redbox/models/file.py
@@ -1,4 +1,5 @@
 import hashlib
+from enum import Enum
 
 import tiktoken
 from langchain.schema import Document
@@ -9,17 +10,27 @@ from redbox.models.base import PersistableModel
 encoding = tiktoken.get_encoding("cl100k_base")
 
 
+class ProcessingStatusEnum(str, Enum):
+    uploading = "uploading"
+    parsing = "parsing"
+    chunking = "chunking"
+    embedding = "embedding"
+    indexing = "indexing"
+    complete = "complete"
+
+
 class File(PersistableModel):
     path: str
     type: str
     name: str
     storage_kind: str = "local"
     text: str = ""
+    processing_status: ProcessingStatusEnum = ProcessingStatusEnum.uploading
 
     @computed_field
     def text_hash(self) -> str:
         return hashlib.md5(
-            self.text.encode(encoding="UTF-8", errors="strict")
+            self.text.encode(encoding="UTF-8", errors="strict"), usedforsecurity=False
         ).hexdigest()
 
     @computed_field
@@ -42,7 +53,7 @@ class Chunk(PersistableModel):
     @computed_field
     def text_hash(self) -> str:
         return hashlib.md5(
-            self.text.encode(encoding="UTF-8", errors="strict")
+            self.text.encode(encoding="UTF-8", errors="strict"), usedforsecurity=False
         ).hexdigest()
 
     @computed_field

--- a/redbox/models/file.py
+++ b/redbox/models/file.py
@@ -11,7 +11,7 @@ encoding = tiktoken.get_encoding("cl100k_base")
 
 
 class ProcessingStatusEnum(str, Enum):
-    uploading = "uploading"
+    uploaded = "uploaded"
     parsing = "parsing"
     chunking = "chunking"
     embedding = "embedding"
@@ -25,7 +25,7 @@ class File(PersistableModel):
     name: str
     storage_kind: str = "local"
     text: str = ""
-    processing_status: ProcessingStatusEnum = ProcessingStatusEnum.uploading
+    processing_status: ProcessingStatusEnum = ProcessingStatusEnum.uploaded
 
     @computed_field
     def text_hash(self) -> str:


### PR DESCRIPTION
## Context

While there was already an upload method in the `core-api`, there was no way for the front end to find out whether the file had been ingested or embedded. In the future, we anticipate a polling mechanism that can check on the status of a particular file upload. 

## Changes proposed in this pull request
* adds a status to the `File` model, which will allow the front end to give information to users about the status of their upload
* updates the docs in line with the new endpoints

## Guidance to review
Do the File statuses make sense? Are the trigger points for updating them in the right place?

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-76 

## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
