### PR TITLE
Feature/redbox 74 trigger embedding post ingest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,7 +163,6 @@ services:
       - elasticsearch
     restart: unless-stopped
   rabbitmq:
-    user: "423642704:849146750"
     image: rabbitmq:3-management-alpine
     ports:
       - 5672:5672

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,7 @@ services:
       - elasticsearch
     restart: unless-stopped
   rabbitmq:
+    user: "423642704:849146750"
     image: rabbitmq:3-management-alpine
     ports:
       - 5672:5672

--- a/ingest/src/app.py
+++ b/ingest/src/app.py
@@ -28,6 +28,14 @@ class FileIngestor:
         self.channel = channel
 
     def ingest_file(self, file: File):
+        """
+        1. Gets up file from s3
+        2. Chunks file
+        3. Puts chunks to ES
+        4. Acknowledges message
+        5. Puts chunk on embed-queue
+        """
+
         logging.info(f"Ingesting file: {file}")
 
         authenticated_s3_url = self.raw_file_source.generate_presigned_url(
@@ -76,11 +84,7 @@ def run():
     """
     0. Listens to queue
     1. On Receipt of a File metadata message from queue
-    2. Callbacks to ingest_file, which:
-     2.1. Gets up file from s3
-     2.2. Chunks file
-     2.3. Puts chunks to ES
-     2.4. Acknowledges message
+    2. Callbacks to ingest_file
     """
 
     # ====== Loading embedding model ======

--- a/ingest/tests/conftest.py
+++ b/ingest/tests/conftest.py
@@ -3,6 +3,8 @@ from typing import TypeVar, Generator
 
 import pytest
 from elasticsearch import Elasticsearch
+from pika import BlockingConnection
+from pika.adapters.blocking_connection import BlockingChannel
 from sentence_transformers import SentenceTransformer
 
 from redbox.models import File
@@ -85,3 +87,21 @@ def file(s3_client, file_pdf_path, bucket):
     )
 
     yield file_record
+
+
+@pytest.fixture
+def rabbitmq_connection() -> YieldFixture[BlockingConnection]:
+    connection = env.blocking_connection()
+    yield connection
+    connection.close()
+
+
+@pytest.fixture
+def rabbitmq_channel(rabbitmq_connection: BlockingConnection) -> YieldFixture[BlockingChannel]:
+    channel = rabbitmq_connection.channel()
+    channel.queue_declare(
+        queue=env.embed_queue_name,
+        durable=True,
+    )
+    yield channel
+    channel.close()

--- a/ingest/tests/test_app.py
+++ b/ingest/tests/test_app.py
@@ -1,21 +1,27 @@
+import json
+
 from ingest.src.app import FileIngestor
+from redbox.models import Settings
 from redbox.models import ProcessingStatusEnum
 from redbox.parsing.file_chunker import FileChunker
 from redbox.storage import ElasticsearchStorageHandler
 
+env = Settings()
 
-def test_ingest_file(s3_client, es_client, embedding_model, file):
+
+def test_ingest_file(s3_client, es_client, embedding_model, file, rabbitmq_channel):
     """
     Given that I have written a text File to s3
     When I call ingest_file
-    I Expect to see this file to be chunked and written to Elasticsearch
+    I Expect to see this file to be:
+    1. chunked
+    2. written to Elasticsearch
+    3. a message put on the embed-queue
     """
 
-    storage_handler = ElasticsearchStorageHandler(
-        es_client=es_client, root_index="redbox-data"
-    )
+    storage_handler = ElasticsearchStorageHandler(es_client=es_client, root_index="redbox-data")
     chunker = FileChunker(embedding_model=embedding_model)
-    file_ingestor = FileIngestor(s3_client, chunker, storage_handler)
+    file_ingestor = FileIngestor(s3_client, chunker, storage_handler, rabbitmq_channel)
     chunks = file_ingestor.ingest_file(file)
     assert chunks
     assert (
@@ -25,3 +31,7 @@ def test_ingest_file(s3_client, es_client, embedding_model, file):
         ).processing_status
         is ProcessingStatusEnum.chunking
     )
+
+    _method, _properties, body = rabbitmq_channel.basic_get(env.embed_queue_name)
+    msg = json.loads(body)
+    assert msg["model_type"] == "Chunk"


### PR DESCRIPTION
## Context

As a User I want the Ingest-app to add messages to the `embed-queue` once it has finished chunking so that the `embed` app knows it should embed the chunks

## Changes proposed in this pull request

I have added code to publish ingested chunks to the embed queue

## Guidance to review

Note that the rabbitmq tests are very flakey in so much that there is no fixture to ensure that the messages created in test do not overlap with those in your local state (obv not a problem in CI). this is probably the answer https://pypi.org/project/pytest-rabbitmq/ but is out of scope

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-74

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
