### PR TITLE
Add document upload page

### DIFF
--- a/django_app/frontend/style.scss
+++ b/django_app/frontend/style.scss
@@ -1,4 +1,33 @@
 $govuk-assets-path: "govuk-assets/";
 $govuk-font-family: sans-serif;
+$iai-pink: #b62777;
 
-@import "django_app/frontend/node_modules/govuk-frontend/dist/govuk/all";
+@import "../node_modules/govuk-frontend/dist/govuk/all";
+
+
+/* Classification banner */
+.iai-classification-banner {
+  background-color: #2b71c7;
+  color: white;
+  font-size: 0.875rem;
+  margin-bottom: 0.25rem;
+  padding: 0.25rem 1rem;
+  text-align: center;
+}
+
+
+/* i.AI pink in header */
+.govuk-header__container {
+  border-color: $iai-pink;
+}
+
+.govuk-phase-banner__content__tag {
+  background-color: $iai-pink;
+  color: white;
+}
+
+
+/* File upload */
+.iai-file-types {
+  font-size: 0.875rem;
+}

--- a/django_app/frontend/style.scss
+++ b/django_app/frontend/style.scss
@@ -2,7 +2,7 @@ $govuk-assets-path: "govuk-assets/";
 $govuk-font-family: sans-serif;
 $iai-pink: #b62777;
 
-@import "../node_modules/govuk-frontend/dist/govuk/all";
+@import "django_app/frontend/node_modules/govuk-frontend/dist/govuk/all";
 
 
 /* Classification banner */

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -9,3 +9,15 @@ def homepage_view(request):
         template_name="homepage.html",
         context={"request": request},
     )
+
+
+def upload_view(request):
+    if request.method == "POST" and request.FILES["uploadDoc"]:
+        doc = request.FILES["uploadDoc"]
+        print(doc)
+        # TO DO: handle file upload here
+    return render(
+        request,
+        template_name="upload.html",
+        context={"request": request},
+    )

--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -3,19 +3,19 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Default – Page template – Example - GOV.UK Design System</title>
+  <title>{% if pageTitle %} {{ pageTitle }} - {% endif %}Redbox Copilot</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c">
 
-  <link rel="icon" sizes="48x48" href="{{static("govuk-assets/images/favicon.ico")}}">
-  <link rel="icon" sizes="any" href="{{static("govuk-assets/images/favicon.svg")}}" type="image/svg+xml">
-  <link rel="mask-icon" href="{{static("govuk-assets/images/govuk-icon-mask.svg")}}" color="#0b0c0c">
-  <link rel="apple-touch-icon" href="{{static("govuk-assets/images/govuk-icon-180.png")}}">
-  <link rel="manifest" href="{{static("govuk-assets/manifest.json")}}">
+  <link rel="icon" sizes="48x48" href="{{static(" govuk-assets/images/favicon.ico")}}">
+  <link rel="icon" sizes="any" href="{{static(" govuk-assets/images/favicon.svg")}}" type="image/svg+xml">
+  <link rel="mask-icon" href="{{static(" govuk-assets/images/govuk-icon-mask.svg")}}" color="#0b0c0c">
+  <link rel="apple-touch-icon" href="{{static(" govuk-assets/images/govuk-icon-180.png")}}">
+  <link rel="manifest" href="{{static(" govuk-assets/manifest.json")}}">
 
   <meta name="robots" content="noindex, nofollow">
   {% compress css %}
-    <link rel="stylesheet" type="text/x-scss" href="{{static("style.scss")}}" />
+  <link rel="stylesheet" type="text/x-scss" href="{{static('style.scss')}}" />
   {% endcompress %}
 
 </head>
@@ -25,11 +25,15 @@
 
   <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 
-
   <header class="govuk-header" role="banner" data-module="govuk-header">
+
+    <div class="iai-classification-banner govuk-body">
+      Up to UK OFFICIAL SENSITIVE documents can be used in this tool
+    </div>
+
     <div class="govuk-header__container govuk-width-container">
       <div class="govuk-header__logo">
-        <a href="/" class="govuk-header__link govuk-header__link--homepage">
+        <a href="https://www.gov.uk/" class="govuk-header__link govuk-header__link--homepage">
           <svg focusable="false" role="img" class="govuk-header__logotype" xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 148 30" height="30" width="148" aria-label="GOV.UK">
             <title>GOV.UK</title>
@@ -39,11 +43,29 @@
           </svg>
         </a>
       </div>
+      <div class="govuk-header__content">
+        <a href="/" class="govuk-header__link govuk-header__service-name">
+          Redbox Copilot
+        </a>
+      </div>
     </div>
   </header>
 
 
   <div class="govuk-width-container">
+
+    {# Phase banner #}
+    <div class="govuk-phase-banner">
+      <p class="govuk-phase-banner__content">
+        <strong class="govuk-tag govuk-phase-banner__content__tag">
+          Beta
+        </strong>
+        <span class="govuk-phase-banner__text">
+          This is a new service – your <a class="govuk-link" href="#feedback">feedback</a> will help us to improve it.
+        </span>
+      </p>
+    </div>
+
     <main class="govuk-main-wrapper" id="main-content" role="main">
       {% block content %}
       {% endblock %}
@@ -54,20 +76,29 @@
     <div class="govuk-width-container">
       <div class="govuk-footer__meta">
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-          <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo"
-            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
-            <path fill="currentColor"
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            class="govuk-footer__licence-logo"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 483.2 195.7"
+            height="17"
+            width="41">
+            <path
+              fill="currentColor"
               d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
           </svg>
           <span class="govuk-footer__licence-description">
             All content is available under the
-            <a class="govuk-footer__link"
-              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open
-              Government Licence v3.0</a>, except where otherwise stated
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license">Open Government Licence v3.0</a>, except where otherwise stated
           </span>
         </div>
         <div class="govuk-footer__meta-item">
-          <a class="govuk-footer__link govuk-footer__copyright-logo"
+          <a
+            class="govuk-footer__link govuk-footer__copyright-logo"
             href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
             © Crown copyright
           </a>
@@ -75,6 +106,7 @@
       </div>
     </div>
   </footer>
+
 </body>
 
 </html>

--- a/django_app/redbox_app/templates/homepage.html
+++ b/django_app/redbox_app/templates/homepage.html
@@ -1,5 +1,6 @@
+{% set pageTitle = "" %}
 {% extends "base.html" %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">it works</h1>
+<h1 class="govuk-heading-xl">Home Page</h1>
 {% endblock %}

--- a/django_app/redbox_app/templates/macros/govuk-button.html
+++ b/django_app/redbox_app/templates/macros/govuk-button.html
@@ -1,0 +1,13 @@
+{% macro govukButton(text=None, secondary=False, href=None) %}
+
+  {% if href %}
+    <a href="{{ href }}" role="button" draggable="false" class="govuk-button {% if secondary %}govuk-button--secondary{% endif %}" data-module="govuk-button">
+      {{ text }}
+    </a>
+  {% else %}
+    <button type="submit" class="govuk-button {% if secondary %}govuk-button--secondary{% endif %}" data-module="govuk-button">
+      {{ text }}
+    </button>
+  {% endif %}
+
+{% endmacro %}

--- a/django_app/redbox_app/templates/upload.html
+++ b/django_app/redbox_app/templates/upload.html
@@ -1,0 +1,25 @@
+{% set pageTitle = "Upload a document" %}
+
+{% extends "base.html" %}
+{% from "macros/govuk-button.html" import govukButton %}
+
+{% block content %}
+<form method="post" enctype="multipart/form-data">
+
+  <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+  <div class="govuk-form-group">
+    <label class="govuk-label" for="upload-doc">
+      <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+    </label>
+    <p class="govuk-body iai-file-types" id="upload-doc-filetypes">Limit 200MB per file: EML, HTML, JSON, MD, MSG, RST, RTF, TXT, XML, CSV, DOC, DOCX, EPUB, ODT, PDF, PPT, PPTX, TSV, XLSX, HTM</p>
+    <input class="govuk-file-upload" id="upload-doc" name="uploadDoc" type="file" aria-describedby="upload-doc-filetypes">
+  </div>
+
+  <div class="govuk-button-group">
+    {{ govukButton(text="Upload") }}
+    {{ govukButton(text="Cancel", secondary=True, href="/documents") }}
+  </div>
+
+</form>
+{% endblock %}

--- a/django_app/redbox_app/urls.py
+++ b/django_app/redbox_app/urls.py
@@ -13,6 +13,7 @@ other_urlpatterns = [
     path("", views.homepage_view, name="homepage"),
     path("admin/", admin.site.urls),
     path("accounts/", include("allauth.urls")),
+    path("upload/", views.upload_view, name="upload"),
 ]
 
 urlpatterns = info_urlpatterns + other_urlpatterns


### PR DESCRIPTION
This is adding a basic document upload page, visible at `/upload`. I've made a start on `views.py`. I've also updated `base.html` for the elements shared across pages.

![image](https://github.com/i-dot-ai/redbox-copilot/assets/1634605/79649b7b-aaf8-487c-9dc4-f27e4065340b)

## How to test

* Check that the page looks okay
* After uploading, the document name should be displayed in the terminal

## Things not covered
* I'm aware of the missing logo in the footer. This can be a separate job.
* The cancel button/link is currently broken, but I'll be looking at that page next!

## Jira link

https://technologyprogramme.atlassian.net/jira/software/projects/REDBOX/boards/409?selectedIssue=REDBOX-71
