### PR TITLE
Feature/document management page

### DIFF
--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -21,3 +21,16 @@ def upload_view(request):
         template_name="upload.html",
         context={"request": request},
     )
+
+
+def documents_view(request):
+    # Testing with some static docs for now
+    documents = [
+        {"id": "doc-id-1", "name": "Document 1", "url": "#download1", "processed": True, "process_status": "Complete"},
+        {"id": "doc-id-2", "name": "Document 2", "url": "#download2", "processed": False, "process_status": "2/5 Parsing"},
+    ]
+    return render(
+        request,
+        template_name="documents.html",
+        context={"request": request, "documents": documents},
+    )

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -11,6 +11,19 @@ def homepage_view(request):
     )
 
 
+def documents_view(request):
+    # Testing with some static docs for now
+    documents = [
+        {"id": "doc-id-1", "name": "Document 1", "url": "#download1", "processed": True, "process_status": "Complete"},
+        {"id": "doc-id-2", "name": "Document 2", "url": "#download2", "processed": False, "process_status": "2/5 Parsing"},
+    ]
+    return render(
+        request,
+        template_name="documents.html",
+        context={"request": request, "documents": documents},
+    )
+
+
 def upload_view(request):
     if request.method == "POST" and request.FILES["uploadDoc"]:
         doc = request.FILES["uploadDoc"]
@@ -23,14 +36,15 @@ def upload_view(request):
     )
 
 
-def documents_view(request):
-    # Testing with some static docs for now
-    documents = [
-        {"id": "doc-id-1", "name": "Document 1", "url": "#download1", "processed": True, "process_status": "Complete"},
-        {"id": "doc-id-2", "name": "Document 2", "url": "#download2", "processed": False, "process_status": "2/5 Parsing"},
-    ]
+def remove_doc_view(request, doc_id: str):
+    if request.method == "POST":
+        print(f"Removing document: {request.POST['doc_id']}")
+        # TO DO: handle document deletion here
+
+    # Hard-coding document name for now, just to flag that this is needed in the template
+    doc_name = "Document X"
     return render(
         request,
-        template_name="documents.html",
-        context={"request": request, "documents": documents},
+        template_name="remove-doc.html",
+        context={"request": request, "doc_id": doc_id, "doc_name": doc_name},
     )

--- a/django_app/redbox_app/templates/documents.html
+++ b/django_app/redbox_app/templates/documents.html
@@ -1,0 +1,48 @@
+{% set pageTitle = "Documents" %}
+{% extends "base.html" %}
+{% from "macros/govuk-button.html" import govukButton %}
+
+{% block content %}
+
+<table class="govuk-table iai-doclist">
+  <caption class="govuk-table__caption govuk-table__caption--m">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Documents</h1>
+  </caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">Status</th>
+      <th scope="col" class="govuk-table__header iai-doclist__actions">Actions</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    {% for document in documents %}
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-!-padding-top-3">{{document.name}}</td>
+        <td class="govuk-table__cell govuk-!-padding-top-3">
+          <strong class="govuk-tag {% if document.processed %}govuk-tag--green{% else %}govuk-tag--yellow{% endif %}">{{document.process_status}}</strong>
+        </td>
+        <td class="govuk-table__cell">
+          {{ govukButton(
+            text="Download",
+            href=document.url,
+            classes="govuk-button--secondary govuk-!-margin-bottom-0",
+            download=True
+          ) }}
+          {{ govukButton(
+            text="Remove",
+            href="/remove-doc/" + document.id,
+            classes="govuk-button--warning govuk-!-margin-bottom-0"
+          ) }}
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+{{ govukButton(
+  text="Upload a new document", 
+  href="/upload"
+) }}
+
+{% endblock %}

--- a/django_app/redbox_app/templates/documents.html
+++ b/django_app/redbox_app/templates/documents.html
@@ -24,13 +24,13 @@
         </td>
         <td class="govuk-table__cell">
           {{ govukButton(
-            text="Download",
+            text="Download" + "<span class=\"govuk-visually-hidden\">" + document.name + "</span>",
             href=document.url,
             classes="govuk-button--secondary govuk-!-margin-bottom-0",
             download=True
           ) }}
           {{ govukButton(
-            text="Remove",
+            text="Remove" + "<span class=\"govuk-visually-hidden\">" + document.name + "</span>",
             href="/remove-doc/" + document.id,
             classes="govuk-button--warning govuk-!-margin-bottom-0"
           ) }}

--- a/django_app/redbox_app/templates/macros/govuk-button.html
+++ b/django_app/redbox_app/templates/macros/govuk-button.html
@@ -1,13 +1,13 @@
-{% macro govukButton(text=None, href=None, classes=None, download=False) %}
+{% macro govukButton(text=None, visually_hidden_text=None, href=None, classes=None, download=False) %}
 
 {% if href %}
   <a href="{{ href }}" role="button" draggable="false" class="govuk-button {{ classes }}" data-module="govuk-button" 
     {% if download %}download{% endif %}>
-    {{ text }}
+    {{ text | safe }}
   </a>
 {% else %}
   <button type="submit" class="govuk-button {{ classes }}" data-module="govuk-button">
-    {{ text }}
+    {{ text | safe }}
   </button>
 {% endif %}
 

--- a/django_app/redbox_app/templates/macros/govuk-button.html
+++ b/django_app/redbox_app/templates/macros/govuk-button.html
@@ -1,13 +1,14 @@
-{% macro govukButton(text=None, secondary=False, href=None) %}
+{% macro govukButton(text=None, href=None, classes=None, download=False) %}
 
-  {% if href %}
-    <a href="{{ href }}" role="button" draggable="false" class="govuk-button {% if secondary %}govuk-button--secondary{% endif %}" data-module="govuk-button">
-      {{ text }}
-    </a>
-  {% else %}
-    <button type="submit" class="govuk-button {% if secondary %}govuk-button--secondary{% endif %}" data-module="govuk-button">
-      {{ text }}
-    </button>
-  {% endif %}
+{% if href %}
+  <a href="{{ href }}" role="button" draggable="false" class="govuk-button {{ classes }}" data-module="govuk-button" 
+    {% if download %}download{% endif %}>
+    {{ text }}
+  </a>
+{% else %}
+  <button type="submit" class="govuk-button {{ classes }}" data-module="govuk-button">
+    {{ text }}
+  </button>
+{% endif %}
 
 {% endmacro %}

--- a/django_app/redbox_app/templates/remove-doc.html
+++ b/django_app/redbox_app/templates/remove-doc.html
@@ -1,0 +1,29 @@
+{% set pageTitle = "Remove document" %}
+
+{% extends "base.html" %}
+{% from "macros/govuk-button.html" import govukButton %}
+
+{% block content %}
+<form method="post" enctype="multipart/form-data">
+
+  <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+  <input type="hidden" name="doc_id" value="{{ doc_id }}">
+
+  <h1 class="govuk-heading-m">Are you sure you want to remove this document?</h1>
+
+  <div class="govuk-body">
+    <dt class="govuk-summary-list__key">
+      Document name:
+    </dt>
+    <dd class="govuk-summary-list__value">
+      {{ doc_name }}
+    </dd>
+  </div> 
+
+  <div class="govuk-button-group">
+    {{ govukButton(text="Remove", classes="govuk-button--warning") }}
+    {{ govukButton(text="Cancel", classes="govuk-button--secondary", href="/documents") }}
+  </div>
+
+</form>
+{% endblock %}

--- a/django_app/redbox_app/templates/upload.html
+++ b/django_app/redbox_app/templates/upload.html
@@ -18,7 +18,7 @@
 
   <div class="govuk-button-group">
     {{ govukButton(text="Upload") }}
-    {{ govukButton(text="Cancel", secondary=True, href="/documents") }}
+    {{ govukButton(text="Cancel", classes="govuk-button--secondary", href="/documents") }}
   </div>
 
 </form>

--- a/django_app/redbox_app/urls.py
+++ b/django_app/redbox_app/urls.py
@@ -13,6 +13,7 @@ other_urlpatterns = [
     path("", views.homepage_view, name="homepage"),
     path("admin/", admin.site.urls),
     path("accounts/", include("allauth.urls")),
+    path("documents/", views.documents_view, name="documents"),
     path("upload/", views.upload_view, name="upload"),
 ]
 

--- a/django_app/redbox_app/urls.py
+++ b/django_app/redbox_app/urls.py
@@ -15,6 +15,7 @@ other_urlpatterns = [
     path("accounts/", include("allauth.urls")),
     path("documents/", views.documents_view, name="documents"),
     path("upload/", views.upload_view, name="upload"),
+    path("remove-doc/<str:doc_id>", views.remove_doc_view, name="remove_doc")
 ]
 
 urlpatterns = info_urlpatterns + other_urlpatterns


### PR DESCRIPTION
## Context

This work is to create a basic document management page, as per Jira ticket:
https://technologyprogramme.atlassian.net/browse/REDBOX-77?atlOrigin=eyJpIjoiYzI1NTE1Y2I2Nzg5NDQzZGJlNjdiYWM1ODAwYjkzNmMiLCJwIjoiaiJ9

This is just the frontend part of the work for now.


## Changes proposed in this pull request

The page looks like this:
![image](https://github.com/i-dot-ai/redbox-copilot/assets/1634605/3be1ebd3-887e-41e0-a1ed-396777a761c3)

This is using dummy data inserted into views.py for now.

There is also a remove-doc page which needs joining up to the backend.

The statuses don't update currently, but once the endpoint is ready we will build in polling to update without needing a page reload. I'll be creating a Jira ticket for that work today.


## Guidance to review

* Visit `/documents/`and check the page looks like the above screenshot
* The "Upload a new document" button takes you to the upload page, which is currently being worked on
* Following the remove document journey should display the document ID in the terminal (but won't actually remove it from the UI)


