### PR TITLE
simplify-download-embeddings

### DIFF
--- a/download_embedder.py
+++ b/download_embedder.py
@@ -1,51 +1,5 @@
-import argparse
-import logging
-import os
-
-from sentence_transformers import SentenceTransformer
-
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger()
-
-
-def download():
-    parser = argparse.ArgumentParser(description="Download Sentence Transformer Embedder")
-    parser.add_argument(
-        "--model_name",
-        type=str,
-        required=False,
-        help="Name of the Sentence Transformer Model",
-        default=None,
-    )
-
-    parser.add_argument(
-        "--models_path",
-        type=str,
-        required=False,
-        help="Path to store the downloaded models",
-        default="models",
-    )
-
-    args = parser.parse_args()
-
-    model_name = "all-mpnet-base-v2"
-
-    if args.model_name is None:
-        logging.warning("❓ No model name provided. Attempting to load EMBEDDING_MODEL from environment")
-        try:
-            model_name = os.environ["EMBEDDING_MODEL"]
-        except KeyError:
-            logging.warning(
-                "❓ No model name provided and EMBEDDING_MODEL not found in environment. Defaulting to all-mpnet-base-v2"
-            )
-    else:
-        logging.info(f"🔎 Model name provided: {args.model_name}")
-        model_name = args.model_name
-
-    log.info(f"💾 Downloading Sentence Transformer Embedder: {model_name}")
-    SentenceTransformer(model_name, cache_folder=args.models_path)
-    log.info(f"✅ Downloaded Sentence Transformer Embedder: {model_name} to {args.models_path}")
+from redbox.model_db import SentenceTransformerDB
 
 
 if __name__ == "__main__":
-    download()
+    SentenceTransformerDB()

--- a/download_embedder.py
+++ b/download_embedder.py
@@ -1,5 +1,9 @@
 from redbox.model_db import SentenceTransformerDB
 
 
-if __name__ == "__main__":
+def download():
     SentenceTransformerDB()
+
+
+if __name__ == "__main__":
+    download()

--- a/redbox/model_db.py
+++ b/redbox/model_db.py
@@ -19,7 +19,9 @@ env = Settings()
 class SentenceTransformerDB(collections.UserDict):
     def __init__(self):
         super().__init__()
+        log.info(f"💾 Downloading Sentence Transformer Embedder: {env.embedding_model}")
         self[env.embedding_model] = SentenceTransformer(env.embedding_model, cache_folder=MODEL_PATH)
+        log.info(f"✅ Downloaded Sentence Transformer Embedder: {env.embedding_model} to {MODEL_PATH}")
 
     def __getitem__(self, model_name: str) -> SentenceTransformer:
         return super().__getitem__(model_name)


### PR DESCRIPTION
## Context

As an engineer I want to remove options that arent yet supported from the code

## Changes proposed in this pull request

`download_embedding` can only usefully initialise the `model_db` with the model found in the settings, the code now reflects that.

## Guidance to review

- [ ] is this what we want?

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests locally
