### PR TITLE
changed api to reflect single model approach

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -51,7 +51,7 @@ jobs:
         docker compose up -d --wait elasticsearch minio
 
         poetry install --no-root --no-ansi --with dev --without ai,streamlit-app,api,worker,ingester
-        poetry run download-model
+        poetry run download-model --model_name paraphrase-albert-small-v2
 
     - name: Test redbox with pytest
       run: |

--- a/core_api/src/app.py
+++ b/core_api/src/app.py
@@ -25,7 +25,7 @@ logging.basicConfig(level=logging.INFO)
 log = logging.getLogger()
 
 env = Settings()
-model_db = SentenceTransformerDB()
+model_db = SentenceTransformerDB(env.embedding_model)
 
 
 # === Object Store ===

--- a/core_api/src/app.py
+++ b/core_api/src/app.py
@@ -217,7 +217,7 @@ def get_model() -> ModelInfo:
     return model_db.get_model_info()
 
 
-@app.post("/models/embed", tags=["models"])
+@app.post("/embedding", tags=["models"])
 def embed_sentences(sentences: list[str]) -> EmbeddingResponse:
     """Embeds a list of sentences using a given model
 

--- a/core_api/tests/test_app.py
+++ b/core_api/tests/test_app.py
@@ -93,32 +93,13 @@ async def test_ingest_file(app_client, stored_file, elasticsearch_storage_handle
         publisher.mock.called_once_with(stored_file)
 
 
-def test_read_all_models(client):
+def test_read_model(client):
     """
-    Given that I have one model, in the database
-    When I GET all models /models
-    I Expect a list of just one model to be returned
+    Given that I have a model in the database
+    When I GET this one model /models/
+    I Expect a model to be returned
     """
-    response = client.get("/models")
-    assert response.status_code == 200
-    assert response.json() == {
-        "models": [
-            {
-                "max_seq_length": 100,
-                "model": env.embedding_model,
-                "vector_size": 768,
-            }
-        ]
-    }
-
-
-def test_read_one_model(client):
-    """
-    Given that I have one model in the database
-    When I GET this one model /models/<name>
-    I Expect a single model to be returned
-    """
-    response = client.get(f"/models/{env.embedding_model}")
+    response = client.get("/model")
     assert response.status_code == 200
     assert response.json() == {
         "max_seq_length": 100,
@@ -127,25 +108,14 @@ def test_read_one_model(client):
     }
 
 
-def test_read_models_404(client):
-    """
-    Given that I have one model in the database
-    When I GET a non-existent model /models/not-a-model
-    I Expect a 404 error
-    """
-    response = client.get("/models/not-a-model")
-    assert response.status_code == 404
-    assert response.json() == {"detail": "Model not-a-model not found"}
-
-
 def test_embed_sentences_422(client):
     """
-    Given that I have one model in the database
-    When I POST a malformed payload to /models/<model-name>/embed
+    Given that I have a model in the database
+    When I POST a mall-formed payload to /models/embed
     I Expect a 422 error
     """
     response = client.post(
-        f"/models/{env.embedding_model}/embed",
+        "/models/embed",
         json={"not": "a well formed payload"},
     )
     assert response.status_code == 422
@@ -154,15 +124,15 @@ def test_embed_sentences_422(client):
 
 def test_embed_sentences(client):
     """
-    Given that I have one model in the database
-    When I POST a valid payload consisting of some sentences to embed to
-    /models/<model-name>/embed
+    Given that I have a model in the database
+    When I POST a valid payload consisting of some sentenced to embed to
+    /models/embed
     I Expect a 200 response
 
     N.B. We are not testing the content / efficacy of the model in this test.
     """
     response = client.post(
-        f"/models/{env.embedding_model}/embed",
+        "/models/embed",
         json=["I am the egg man", "I am the walrus"],
     )
     assert response.status_code == 200

--- a/core_api/tests/test_app.py
+++ b/core_api/tests/test_app.py
@@ -96,8 +96,8 @@ async def test_ingest_file(app_client, stored_file, elasticsearch_storage_handle
 def test_read_model(client):
     """
     Given that I have a model in the database
-    When I GET this one model /models/
-    I Expect a model to be returned
+    When I GET /model
+    I Expect model-info to be returned
     """
     response = client.get("/model")
     assert response.status_code == 200
@@ -111,11 +111,11 @@ def test_read_model(client):
 def test_embed_sentences_422(client):
     """
     Given that I have a model in the database
-    When I POST a mall-formed payload to /models/embed
+    When I POST a mall-formed payload to /embedding
     I Expect a 422 error
     """
     response = client.post(
-        "/models/embed",
+        "/embedding",
         json={"not": "a well formed payload"},
     )
     assert response.status_code == 422
@@ -126,13 +126,13 @@ def test_embed_sentences(client):
     """
     Given that I have a model in the database
     When I POST a valid payload consisting of some sentenced to embed to
-    /models/embed
+    /embedding
     I Expect a 200 response
 
     N.B. We are not testing the content / efficacy of the model in this test.
     """
     response = client.post(
-        "/models/embed",
+        "/embedding",
         json=["I am the egg man", "I am the walrus"],
     )
     assert response.status_code == 200

--- a/download_embedder.py
+++ b/download_embedder.py
@@ -12,23 +12,15 @@ def download():
     parser.add_argument(
         "--model_name",
         type=str,
-        required=False,
+        required=True,
         help="Name of the Sentence Transformer Model",
-        default=None,
     )
 
     args = parser.parse_args()
 
-    if args.model_name is None:
-        logging.error("❓ No model name provided")
-        return
-    else:
-        logging.info(f"🔎 Model name provided: {args.model_name}")
-        model_name = args.model_name
-
-    log.info(f"💾 Downloading Sentence Transformer Embedder: {model_name}")
-    SentenceTransformerDB(model_name)
-    log.info(f"✅ Downloaded Sentence Transformer Embedder: {model_name}")
+    log.info(f"💾 Downloading Sentence Transformer Embedder: {args.model_name}")
+    SentenceTransformerDB(args.model_name)
+    log.info(f"✅ Downloaded Sentence Transformer Embedder: {args.model_name}")
 
 
 if __name__ == "__main__":

--- a/download_embedder.py
+++ b/download_embedder.py
@@ -20,7 +20,7 @@ def download():
     args = parser.parse_args()
 
     if args.model_name is None:
-        logging.error("❓ No model name provided. Attempting to load EMBEDDING_MODEL from environment")
+        logging.error("❓ No model name provided")
         return
     else:
         logging.info(f"🔎 Model name provided: {args.model_name}")

--- a/embedder/src/worker.py
+++ b/embedder/src/worker.py
@@ -25,7 +25,7 @@ embed_channel = RabbitQueue(name=env.embed_queue_name, durable=True, routing_key
 async def lifespan(context: ContextRepo):
     es = env.elasticsearch_client()
     storage_handler = ElasticsearchStorageHandler(es_client=es, root_index="redbox-data")
-    model = SentenceTransformerDB(env.embedding_model)
+    model = SentenceTransformerDB()
 
     context.set_global("storage_handler", storage_handler)
     context.set_global("model", model)
@@ -45,7 +45,7 @@ async def embed(
     """
 
     chunk: Chunk = storage_handler.read_item(queue_item.chunk_uuid, "Chunk")
-    embedded_sentences = model.embed_sentences(queue_item.model, [chunk.text])
+    embedded_sentences = model.embed_sentences([chunk.text])
     if len(embedded_sentences.data) != 1:
         logging.error(f"expected just 1 embedding but got {len(embedded_sentences.data)}")
         return

--- a/embedder/src/worker.py
+++ b/embedder/src/worker.py
@@ -25,7 +25,7 @@ embed_channel = RabbitQueue(name=env.embed_queue_name, durable=True, routing_key
 async def lifespan(context: ContextRepo):
     es = env.elasticsearch_client()
     storage_handler = ElasticsearchStorageHandler(es_client=es, root_index="redbox-data")
-    model = SentenceTransformerDB()
+    model = SentenceTransformerDB(env.embedding_model)
 
     context.set_global("storage_handler", storage_handler)
     context.set_global("model", model)

--- a/embedder/tests/conftest.py
+++ b/embedder/tests/conftest.py
@@ -30,7 +30,7 @@ def chunk() -> YieldFixture[Chunk]:
 
 @pytest.fixture
 def embed_queue_item(stored_chunk) -> YieldFixture[EmbedQueueItem]:
-    yield EmbedQueueItem(model=env.embedding_model, chunk_uuid=stored_chunk.uuid)
+    yield EmbedQueueItem(chunk_uuid=stored_chunk.uuid)
 
 
 @pytest.fixture

--- a/ingester/src/worker.py
+++ b/ingester/src/worker.py
@@ -32,8 +32,8 @@ async def lifespan(context: ContextRepo):
     s3_client = env.s3_client()
     es = env.elasticsearch_client()
     storage_handler = ElasticsearchStorageHandler(es_client=es, root_index="redbox-data")
-    model_db = SentenceTransformerDB(env.embedding_model)
-    chunker = FileChunker(embedding_model=model_db[env.embedding_model])
+    model_db = SentenceTransformerDB()
+    chunker = FileChunker(embedding_model=model_db)
 
     context.set_global("s3_client", s3_client)
     context.set_global("storage_handler", storage_handler)
@@ -79,7 +79,7 @@ async def ingest(
     logging.info(f"written {len(items)} chunks to elasticsearch")
 
     for chunk in chunks:
-        queue_item = EmbedQueueItem(model=env.embedding_model, chunk_uuid=chunk.uuid)
+        queue_item = EmbedQueueItem(chunk_uuid=chunk.uuid)
         logging.info(f"Writing chunk to storage for chunk uuid: {chunk.uuid}")
         await publisher.publish(queue_item)
     return items

--- a/ingester/src/worker.py
+++ b/ingester/src/worker.py
@@ -32,7 +32,7 @@ async def lifespan(context: ContextRepo):
     s3_client = env.s3_client()
     es = env.elasticsearch_client()
     storage_handler = ElasticsearchStorageHandler(es_client=es, root_index="redbox-data")
-    model_db = SentenceTransformerDB()
+    model_db = SentenceTransformerDB(env.embedding_model)
     chunker = FileChunker(embedding_model=model_db)
 
     context.set_global("s3_client", s3_client)

--- a/redbox/model_db.py
+++ b/redbox/model_db.py
@@ -15,16 +15,7 @@ log.setLevel(logging.INFO)
 
 
 class SentenceTransformerDB(SentenceTransformer):
-    def __init__(self, model_name: Optional[str] = None):
-        if model_name is None:
-            try:
-                model_name = next(
-                    dir_name.split("--")[-1]
-                    for dir_name in os.listdir(MODEL_PATH)
-                    if dir_name.startswith("models--sentence-transformers--")
-                )
-            except StopIteration:
-                raise StopIteration("no model found on disk")
+    def __init__(self, model_name: str):
         super().__init__(model_name, cache_folder=MODEL_PATH)
         self.model_name = model_name
 

--- a/redbox/models/__init__.py
+++ b/redbox/models/__init__.py
@@ -3,7 +3,7 @@ from redbox.models.collection import Collection
 from redbox.models.feedback import Feedback
 from redbox.models.file import Chunk, File, ProcessingStatusEnum
 from redbox.models.llm import (EmbeddingResponse, EmbedQueueItem, ModelInfo,
-                               ModelListResponse, StatusResponse)
+                               StatusResponse)
 from redbox.models.persona import ChatPersona
 from redbox.models.settings import Settings
 from redbox.models.spotlight import (Spotlight, SpotlightComplete,
@@ -22,7 +22,6 @@ __all__ = [
     "SpotlightTaskComplete",
     "Settings",
     "ModelInfo",
-    "ModelListResponse",
     "EmbeddingResponse",
     "EmbedQueueItem",
     "StatusResponse",

--- a/redbox/models/llm.py
+++ b/redbox/models/llm.py
@@ -35,5 +35,5 @@ class StatusResponse(BaseModel):
 
 
 class EmbedQueueItem(BaseModel):
-    """Instruction to Ingest app for what to embed, and how"""
+    """Instruction to Ingest app for what to embed"""
     chunk_uuid: str = Field(description="id of the chunk that this text belongs to")

--- a/redbox/models/llm.py
+++ b/redbox/models/llm.py
@@ -28,10 +28,6 @@ class EmbeddingRequest(BaseModel):
     sentences: list[str]
 
 
-class ModelListResponse(BaseModel):
-    models: list[ModelInfo]
-
-
 class StatusResponse(BaseModel):
     status: str
     uptime_seconds: float
@@ -39,6 +35,5 @@ class StatusResponse(BaseModel):
 
 
 class EmbedQueueItem(BaseModel):
-    """Instruction to Ingester app for what to embedder, and how"""
-    model: str = Field(description="model to be used to embed sentence")
+    """Instruction to Ingest app for what to embed, and how"""
     chunk_uuid: str = Field(description="id of the chunk that this text belongs to")


### PR DESCRIPTION
## Context

The code should reflect that we only ever have one model per environment.

## Changes proposed in this pull request

* `SentenceTransformerDB` now inherits from `SentenceTransformer`
* we only use `env.embedding_model` where absolutely necessary
* `core-api` has become simpler

## Guidance to review

- [ ] do we want this?

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests locally
