### PR TITLE
added EMBEDDING_MODEL to streamlit-app build

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
     build:
       context: .
       dockerfile: ./streamlit_app/Dockerfile
+      args:
+        - EMBEDDING_MODEL=${EMBEDDING_MODEL:-}
     env_file:
       - .env
     ports:

--- a/streamlit_app/Dockerfile
+++ b/streamlit_app/Dockerfile
@@ -27,8 +27,7 @@ COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 ADD redbox/ /app/redbox
 ADD download_embedder.py /app/
-RUN python download_embedder.py
-
+RUN python download_embedder.py --model_name ${EMBEDDING_MODEL}
 ADD streamlit_app/ /app
 
 EXPOSE 8501


### PR DESCRIPTION
## Context

This PR fixes a big where it is not possible to run `docker compose build streamlit-app` because we made a breaking change to the `download_model.py` so that the `--model_name` is now required.

## Changes proposed in this pull request

Following the pattern established in the other services the `EMBEDDING_MODEL` is now read from the `.env` and passed into the `Dockerfile` as an `ARG`

## Guidance to review

Does `docker compose build streamlit-app` work locally?

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests locally
