### PR TITLE
fix integration tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,6 @@ INGEST_QUEUE_NAME=redbox-ingester-queue
 
 REDIS_HOST=redis
 REDIS_PORT=6379
-REDIS_PASSWORD=eYVX7EwVmmxKPCDmwMtyKVge8oLd2t81
 
 # === Django App ===
 DJANGO_SETTINGS_MODULE=redbox_app.settings

--- a/.env.test
+++ b/.env.test
@@ -46,7 +46,6 @@ INGEST_QUEUE_NAME=redbox-ingester-queue
 
 REDIS_HOST=localhost
 REDIS_PORT=6379
-REDIS_PASSWORD=eYVX7EwVmmxKPCDmwMtyKVge8oLd2t81
 
 # === Django App ===
 DJANGO_SETTINGS_MODULE=redbox_app.settings

--- a/README.md
+++ b/README.md
@@ -121,32 +121,6 @@ colima down
 colima start --memory 8
 ```
 
-
-#### Error: RabbitMQ permissions
-```commandline
-rabbitmq-1            | chown: /var/lib/rabbitmq: Permission denied
-```
-
-This is caused my rabbitmq not having access the volumes defined in docker-compose.yml.
-
-First try running the following:
-
-```commandline
-chmod -R 777 ./data
-chmod -R 777 ./infra
-```
-
-If this doesn't work then update the `rabbitmq` service in the `docker-compose.yml`
-by adding a new `user` key so that the container assumes your own identity, i.e.:
-
-```yaml
-  rabbitmq:
-    image: rabbitmq:3-management
-    user: "{UID}:{GID}"
-```
-
-Where `UID` and `GID` can be found by running `id -u` and `id -g` respectively.
-
 #### Error: Docker... no space left on device
 
 ```commandline

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,6 @@ services:
     restart: always
     ports:
       - "6379:6379"
-    command: redis-server --requirepass {REDIS_PASSWORD:-}
     volumes:
       - redis:/data/redis
     env_file:

--- a/redbox/models/settings.py
+++ b/redbox/models/settings.py
@@ -42,7 +42,6 @@ class Settings(BaseSettings):
 
     redis_host: str = "redis"
     redis_port: int = 6379
-    redis_password: str = "guest"
 
     dev_mode: bool = False
     django_settings_module: str = "redbox_app.settings"
@@ -92,16 +91,7 @@ class Settings(BaseSettings):
 
         raise NotImplementedError
 
-    def sqs_client(self):
-        sqs = boto3.client(
-            "sqs",
-            aws_access_key_id=self.aws_access_key_id,
-            aws_secret_access_key=self.aws_secret_access_key,
-            region_name=self.aws_region,
-        )
-        return sqs
-
     @property
     def redis_url(self) -> str:
-        return f"redis://:{self.redis_password}@{self.redis_host}:{self.redis_port}/"
+        return f"redis://{self.redis_host}:{self.redis_port}/"
 


### PR DESCRIPTION
## Context

The integration tests were broken when we moved from `rabbitmq` to `redis`, this is because the `redis` username/password was incorrectly set up. Fixing the `redis` auth will be tackled in another ticket, this PR just gets the tests passing again.

## Changes proposed in this pull request

1. `redis` auth has been removed
2. error in integration tests has been corrected
3. some minor corrections to the README has been made 

## Guidance to review

does `make test-integration` work for you?

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests locally
