### PR TITLE
Fix summary-list on remove-doc page

### DIFF
--- a/django_app/redbox_app/templates/remove-doc.html
+++ b/django_app/redbox_app/templates/remove-doc.html
@@ -11,14 +11,16 @@
 
   <h1 class="govuk-heading-m">Are you sure you want to remove this document?</h1>
 
-  <div class="govuk-body">
-    <dt class="govuk-summary-list__key">
-      Document name:
-    </dt>
-    <dd class="govuk-summary-list__value">
-      {{ doc_name }}
-    </dd>
-  </div> 
+  <dl class="govuk-summary-list">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Document name:
+      </dt>
+      <dd class="govuk-summary-list__value">
+        {{ doc_name }}
+      </dd>
+    </div>
+  </dl>
 
   <div class="govuk-button-group">
     {{ govukButton(text="Remove", classes="govuk-button--warning") }}


### PR DESCRIPTION
## Context

This is just a small HTML fix on the `/remove-doc/<doc-id>` page. The summary-list wasn't properly formed. Picked up as part of the auto-accessibility testing work!

## Guidance to review

Visit the above URL and inspect the page. Check that the `<dt>` and `<dd>` are inside a `<dl>`. The `<div>` in-between is fine :-)
