### PR TITLE
integration tests are turned off

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,4 +17,4 @@
 
 - [ ] I have added any new ENV vars in all deployed environments
 - [ ] I have tested any code added or changed
-- [ ] I have run integration tests locally
+- [ ] I have run integration tests

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,10 +4,6 @@
 name: Integration Tests
 
 on:
-  push:
-    branches:
-      - 'feature/**'
-
   # weekday mealtimes
   schedule:
     - cron: '* 6,12,18 * * 1-5'


### PR DESCRIPTION
## Context

We dont need integration tests to be run every time someone pushes to a PR, they are already run:
* 3 times daily on `main`
* on demand

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests locally
