### PR TITLE
unstructured now on v0.13

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Add dependencies for Ingester
       run: |
-        apt update && apt-get install -y \
+        sudo apt update && apt-get install -y \
         poppler-utils \
         tesseract-ocr
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -53,6 +53,12 @@ jobs:
         poetry install --no-root --no-ansi --with dev --without ai,streamlit-app,api,worker,ingester
         poetry run download-model --model_name paraphrase-albert-small-v2
 
+    - name: Add dependencies for Ingester
+      run: |
+        apt update && apt-get install -y \
+        poppler-utils \
+        tesseract-ocr
+
     - name: Test redbox with pytest
       run: |
         make test-redbox

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Add dependencies for Ingester
       run: |
-        sudo apt update && apt-get install -y \
+        sudo apt update && sudo apt-get install -y \
         poppler-utils \
         tesseract-ocr
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ For a quick start, you can use GitHub Codespaces to run the project in a cloud-b
 
 # Development
 
+You will need to install `poppler` and `tesseract` to run the `ingester`
+- `brew install poppler`
+- `brew install tesseract`
+
 - Download and install [pre-commit](https://pre-commit.com) to benefit from pre-commit hooks
   - `pip install pre-commit`
   - `pre-commit install`

--- a/ingester/Dockerfile
+++ b/ingester/Dockerfile
@@ -14,7 +14,7 @@ ADD download_embedder.py /app/
 RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install --no-root --no-ansi --with worker,ingester --without ai,dev,api,streamlit-app
 
 FROM python:3.11-slim-buster as runtime
-RUN apt update && sudo apt-get install -y \
+RUN apt update && apt-get install -y \
     poppler-utils \
     tesseract-ocr
 

--- a/ingester/Dockerfile
+++ b/ingester/Dockerfile
@@ -14,6 +14,10 @@ ADD download_embedder.py /app/
 RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install --no-root --no-ansi --with worker,ingester --without ai,dev,api,streamlit-app
 
 FROM python:3.11-slim-buster as runtime
+RUN apt update && apt-get install -y \
+    poppler-utils \
+    tesseract-ocr
+
 ARG EMBEDDING_MODEL
 
 ENV VIRTUAL_ENV=/app/.venv \

--- a/ingester/Dockerfile
+++ b/ingester/Dockerfile
@@ -14,7 +14,7 @@ ADD download_embedder.py /app/
 RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install --no-root --no-ansi --with worker,ingester --without ai,dev,api,streamlit-app
 
 FROM python:3.11-slim-buster as runtime
-RUN apt update && apt-get install -y \
+RUN apt update && sudo apt-get install -y \
     poppler-utils \
     tesseract-ocr
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -456,17 +456,17 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.34.75"
+version = "1.34.76"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.34.75-py3-none-any.whl", hash = "sha256:ba5d2104bba4370766036d64ad9021eb6289d154265852a2a821ec6a5e816faa"},
-    {file = "boto3-1.34.75.tar.gz", hash = "sha256:eaec72fda124084105a31bcd67eafa1355b34df6da70cadae0c0f262d8a4294f"},
+    {file = "boto3-1.34.76-py3-none-any.whl", hash = "sha256:530a4cea3d40a6bd2f15a368ea395beef1ea6dff4491823bc48bd20c7d4da655"},
+    {file = "boto3-1.34.76.tar.gz", hash = "sha256:8c598382e8fb61cfa8f75056197e9b509eb52039ebc291af3b1096241ba2542c"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.75,<1.35.0"
+botocore = ">=1.34.76,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -475,13 +475,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "boto3-stubs"
-version = "1.34.75"
-description = "Type annotations for boto3 1.34.75 generated with mypy-boto3-builder 7.23.2"
+version = "1.34.76"
+description = "Type annotations for boto3 1.34.76 generated with mypy-boto3-builder 7.23.2"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-stubs-1.34.75.tar.gz", hash = "sha256:bb55fe97f474ea800c762592d81369bb6c23a8e53a5b2d8497145f87c1d7640c"},
-    {file = "boto3_stubs-1.34.75-py3-none-any.whl", hash = "sha256:78093a0bf5a03bc66a79d6cddb9f0eb67b67ed6b008cba4cf394c0c9d11de2c1"},
+    {file = "boto3-stubs-1.34.76.tar.gz", hash = "sha256:804fe62e19f4f1295784fe2285ba028a05b2d510bceb65323d37d49ede183d07"},
+    {file = "boto3_stubs-1.34.76-py3-none-any.whl", hash = "sha256:5cbe4f05df5887062f1a7e7a973d06e19a3f169f13178a997d0ac47be13669ed"},
 ]
 
 [package.dependencies]
@@ -532,7 +532,7 @@ bedrock-agent = ["mypy-boto3-bedrock-agent (>=1.34.0,<1.35.0)"]
 bedrock-agent-runtime = ["mypy-boto3-bedrock-agent-runtime (>=1.34.0,<1.35.0)"]
 bedrock-runtime = ["mypy-boto3-bedrock-runtime (>=1.34.0,<1.35.0)"]
 billingconductor = ["mypy-boto3-billingconductor (>=1.34.0,<1.35.0)"]
-boto3 = ["boto3 (==1.34.75)", "botocore (==1.34.75)"]
+boto3 = ["boto3 (==1.34.76)", "botocore (==1.34.76)"]
 braket = ["mypy-boto3-braket (>=1.34.0,<1.35.0)"]
 budgets = ["mypy-boto3-budgets (>=1.34.0,<1.35.0)"]
 ce = ["mypy-boto3-ce (>=1.34.0,<1.35.0)"]
@@ -877,13 +877,13 @@ xray = ["mypy-boto3-xray (>=1.34.0,<1.35.0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.75"
+version = "1.34.76"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.34.75-py3-none-any.whl", hash = "sha256:1d7f683d99eba65076dfb9af3b42fa967c64f11111d9699b65757420902aa002"},
-    {file = "botocore-1.34.75.tar.gz", hash = "sha256:06113ee2587e6160211a6bd797e135efa6aa21b5bde97bf455c02f7dff40203c"},
+    {file = "botocore-1.34.76-py3-none-any.whl", hash = "sha256:62e45e7374844ee39e86a96fe7f5e973eb5bf3469da028b4e3a8caba0909fb1f"},
+    {file = "botocore-1.34.76.tar.gz", hash = "sha256:68be44487a95132fccbc0b836fded4190dae30324f6bf822e1b6efd385ffdc83"},
 ]
 
 [package.dependencies]
@@ -3080,13 +3080,13 @@ extended-testing = ["aiosqlite (>=0.19.0,<0.20.0)", "aleph-alpha-client (>=2.15.
 
 [[package]]
 name = "langchain-core"
-version = "0.1.38"
+version = "0.1.39"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langchain_core-0.1.38-py3-none-any.whl", hash = "sha256:d881b2754254cb4bdb0d5bb56e5c138d032b6e75e5cb21f151b01224b322e02b"},
-    {file = "langchain_core-0.1.38.tar.gz", hash = "sha256:ee8da6d061c06cce7dc22fec224b6ecbc3a8de106d6dd9f409c7fe448ea41861"},
+    {file = "langchain_core-0.1.39-py3-none-any.whl", hash = "sha256:26b024ef49c5a712611941651bff66fb9a2fd7bc82bd815934c94f0ecf9b6f03"},
+    {file = "langchain_core-0.1.39.tar.gz", hash = "sha256:a34bd517dcd9b7e80adf131ee47554736f9532e1bba17593cd0a316a38ec2caf"},
 ]
 
 [package.dependencies]
@@ -3095,7 +3095,6 @@ langsmith = ">=0.1.0,<0.2.0"
 packaging = ">=23.2,<24.0"
 pydantic = ">=1,<3"
 PyYAML = ">=5.3"
-requests = ">=2,<3"
 tenacity = ">=8.1.0,<9.0.0"
 
 [package.extras]
@@ -3134,13 +3133,13 @@ six = "*"
 
 [[package]]
 name = "langsmith"
-version = "0.1.38"
+version = "0.1.39"
 description = "Client library to connect to the LangSmith LLM Tracing and Evaluation Platform."
 optional = false
 python-versions = "<4.0,>=3.8.1"
 files = [
-    {file = "langsmith-0.1.38-py3-none-any.whl", hash = "sha256:f36479f82cf537cf40d129ac2e485e72a3981360c7b6cf2549dad77d98eafd8f"},
-    {file = "langsmith-0.1.38.tar.gz", hash = "sha256:2c1f98ac0a8c02e43b625650a6e13c65b09523551bfc21a59d20963f46f7d265"},
+    {file = "langsmith-0.1.39-py3-none-any.whl", hash = "sha256:85c19177162585728001cb7ae91ab48ca4abe39b7bc1ff783212ac426ded222b"},
+    {file = "langsmith-0.1.39.tar.gz", hash = "sha256:2aec9d2f9cc664042d2121b13da569b0902aff842c86b17b440245d57da84ec5"},
 ]
 
 [package.dependencies]
@@ -3184,13 +3183,13 @@ tesseract = ["pytesseract"]
 
 [[package]]
 name = "litellm"
-version = "1.34.21"
+version = "1.34.22"
 description = "Library to easily interface with LLM API providers"
 optional = false
 python-versions = "!=2.7.*,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,!=3.7.*,>=3.8"
 files = [
-    {file = "litellm-1.34.21-py3-none-any.whl", hash = "sha256:3cc9d60ac50ca4e76f5ef9c2d5438ee2789283bb6cd0ce70e58fb12409bc9e3f"},
-    {file = "litellm-1.34.21.tar.gz", hash = "sha256:a87f5d2b165fb94b3e8662f8a7f2a7a9be15be0399ad4a4025ed876aa20f8378"},
+    {file = "litellm-1.34.22-py3-none-any.whl", hash = "sha256:0e573d56d762f4060c53493da4a08c48034b5bb5ba22e34517065739adfd9154"},
+    {file = "litellm-1.34.22.tar.gz", hash = "sha256:ca50ede3ca8d3f9dc2765ca13cf2ff5c4e4b9afb4db222f9d7cb9ee838b6180f"},
 ]
 
 [package.dependencies]
@@ -3723,13 +3722,13 @@ test = ["mkdocs-material"]
 
 [[package]]
 name = "mkdocstrings"
-version = "0.24.1"
+version = "0.24.2"
 description = "Automatic documentation from sources, for MkDocs."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocstrings-0.24.1-py3-none-any.whl", hash = "sha256:b4206f9a2ca8a648e222d5a0ca1d36ba7dee53c88732818de183b536f9042b5d"},
-    {file = "mkdocstrings-0.24.1.tar.gz", hash = "sha256:cc83f9a1c8724fc1be3c2fa071dd73d91ce902ef6a79710249ec8d0ee1064401"},
+    {file = "mkdocstrings-0.24.2-py3-none-any.whl", hash = "sha256:61440b77542170238099a7d87882c3417897771950e3aafe6e22abff3d1c51fb"},
+    {file = "mkdocstrings-0.24.2.tar.gz", hash = "sha256:b91b9cdd9490ef2e8957000bff1d34a4b308b9cd57b10f26169f085def4c6a92"},
 ]
 
 [package.dependencies]
@@ -3750,19 +3749,18 @@ python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
 
 [[package]]
 name = "mkdocstrings-python"
-version = "1.9.1"
+version = "1.9.2"
 description = "A Python handler for mkdocstrings."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocstrings_python-1.9.1-py3-none-any.whl", hash = "sha256:bf2406ed37ff19c9f8e0acc9d72c41953fb789bfb4ae10eb00ee17e537eeb220"},
-    {file = "mkdocstrings_python-1.9.1.tar.gz", hash = "sha256:077188fa43eab3b689826b15da7da6753501224b2482e4eca3ce4412ce3b71cb"},
+    {file = "mkdocstrings_python-1.9.2-py3-none-any.whl", hash = "sha256:96d82f6424e08db6245e4a15ca95619f4ecd0ddd254c0aa590d4181814e16ee5"},
+    {file = "mkdocstrings_python-1.9.2.tar.gz", hash = "sha256:8546a103c9b22e1778c72c887696acc39a6635fedde3c912ce00f967518a8847"},
 ]
 
 [package.dependencies]
 griffe = ">=0.37"
-markdown = ">=3.3,<3.6"
-mkdocstrings = ">=0.20"
+mkdocstrings = ">=0.24.2"
 
 [[package]]
 name = "mpmath"
@@ -7733,13 +7731,13 @@ files = [
 
 [[package]]
 name = "unstructured"
-version = "0.12.6"
+version = "0.13.0"
 description = "A library that prepares raw documents for downstream ML tasks."
 optional = false
-python-versions = ">=3.9.0,<3.12"
+python-versions = "<3.12,>=3.9.0"
 files = [
-    {file = "unstructured-0.12.6-py3-none-any.whl", hash = "sha256:b317957d9d34e23ad884acb2ee48d93afad9f9c10b77c1a764b0459c7a807efc"},
-    {file = "unstructured-0.12.6.tar.gz", hash = "sha256:fd971c5ae15730d7303e3c0cf493d5393ec6ca742c7f02f8ba5da1778a92c6f4"},
+    {file = "unstructured-0.13.0-py3-none-any.whl", hash = "sha256:808efd113f43890d0abe3e3f4ee2d6d440d486cd6ee21f54d6941304522dee2d"},
+    {file = "unstructured-0.13.0.tar.gz", hash = "sha256:cc65038ee76e63aa48279b70fddfbc8cba2ea5ff34eef778630546c9e366fb3b"},
 ]
 
 [package.dependencies]
@@ -7839,7 +7837,7 @@ typing-extensions = "4.9.0"
 typing-inspect = "0.9.0"
 tzdata = {version = "2024.1", optional = true, markers = "extra == \"all-docs\""}
 unstructured-client = "0.18.0"
-unstructured-inference = {version = "0.7.23", optional = true, markers = "extra == \"all-docs\""}
+unstructured-inference = {version = "0.7.25", optional = true, markers = "extra == \"all-docs\""}
 unstructured-pytesseract = {version = "0.3.12", optional = true, markers = "extra == \"all-docs\""}
 urllib3 = "1.26.18"
 wrapt = "1.16.0"
@@ -7849,14 +7847,15 @@ zipp = {version = "3.17.0", optional = true, markers = "extra == \"all-docs\""}
 
 [package.extras]
 airtable = ["certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "idna (==3.6)", "inflection (==0.5.1)", "pyairtable (==2.2.2)", "pydantic (==1.10.14)", "requests (==2.31.0)", "typing-extensions (==4.9.0)", "urllib3 (==1.26.18)"]
-all-docs = ["antlr4-python3-runtime (==4.9.3)", "certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "coloredlogs (==15.0.1)", "contourpy (==1.2.0)", "cryptography (==42.0.2)", "cycler (==0.12.1)", "deprecated (==1.2.14)", "effdet (==0.4.1)", "et-xmlfile (==1.1.0)", "filelock (==3.13.1)", "flatbuffers (==23.5.26)", "fonttools (==4.49.0)", "fsspec (==2024.2.0)", "huggingface-hub (==0.20.3)", "humanfriendly (==10.0)", "idna (==3.6)", "importlib-metadata (==7.0.1)", "importlib-resources (==6.1.1)", "iopath (==0.1.10)", "jinja2 (==3.1.3)", "kiwisolver (==1.4.5)", "layoutparser[layoutmodels,tesseract] (==0.3.4)", "lxml (==5.1.0)", "markdown (==3.5.2)", "markupsafe (==2.1.5)", "matplotlib (==3.7.2)", "mpmath (==1.3.0)", "msg-parser (==1.2.0)", "networkx (==3.2.1)", "numpy (==1.26.4)", "olefile (==0.47)", "omegaconf (==2.3.0)", "onnx (==1.15.0)", "onnxruntime (==1.15.1)", "opencv-python (==4.8.0.76)", "openpyxl (==3.1.2)", "packaging (==23.2)", "pandas (==2.2.0)", "pdf2image (==1.17.0)", "pdfminer-six (==20221105)", "pdfplumber (==0.10.4)", "pikepdf (==8.11.0)", "pillow (==10.2.0)", "pillow-heif (==0.15.0)", "portalocker (==2.8.2)", "protobuf (==4.23.4)", "pycocotools (==2.0.7)", "pycparser (==2.21)", "pypandoc (==1.12)", "pyparsing (==3.0.9)", "pypdf (==4.0.1)", "pypdfium2 (==4.27.0)", "pytesseract (==0.3.10)", "python-dateutil (==2.8.2)", "python-docx (==1.1.0)", "python-multipart (==0.0.9)", "python-pptx (==0.6.23)", "pytz (==2024.1)", "pyyaml (==6.0.1)", "rapidfuzz (==3.6.1)", "regex (==2023.12.25)", "requests (==2.31.0)", "safetensors (==0.3.2)", "scipy (==1.10.1)", "six (==1.16.0)", "sympy (==1.12)", "timm (==0.9.12)", "tokenizers (==0.15.2)", "torch (==2.2.0)", "torchvision (==0.17.0)", "tqdm (==4.66.2)", "transformers (==4.37.1)", "typing-extensions (==4.9.0)", "tzdata (==2024.1)", "unstructured-inference (==0.7.23)", "unstructured-pytesseract (==0.3.12)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)", "xlrd (==2.0.1)", "xlsxwriter (==3.1.9)", "zipp (==3.17.0)"]
-astra = ["anyio (==3.7.1)", "astrapy (==0.7.6)", "cassandra-driver (==3.29.0)", "cassio (==0.1.5)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "click (==8.1.7)", "deprecation (==2.1.0)", "exceptiongroup (==1.2.0)", "geomet (==0.2.1.post1)", "h11 (==0.14.0)", "h2 (==4.1.0)", "hpack (==4.0.0)", "httpcore (==1.0.4)", "httpx[http2] (==0.27.0)", "hyperframe (==6.0.1)", "idna (==3.6)", "numpy (==1.26.4)", "packaging (==23.2)", "requests (==2.31.0)", "six (==1.16.0)", "sniffio (==1.3.0)", "toml (==0.10.2)", "urllib3 (==1.26.18)"]
+all-docs = ["antlr4-python3-runtime (==4.9.3)", "certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "coloredlogs (==15.0.1)", "contourpy (==1.2.0)", "cryptography (==42.0.2)", "cycler (==0.12.1)", "deprecated (==1.2.14)", "effdet (==0.4.1)", "et-xmlfile (==1.1.0)", "filelock (==3.13.1)", "flatbuffers (==23.5.26)", "fonttools (==4.49.0)", "fsspec (==2024.2.0)", "huggingface-hub (==0.20.3)", "humanfriendly (==10.0)", "idna (==3.6)", "importlib-metadata (==7.0.1)", "importlib-resources (==6.1.1)", "iopath (==0.1.10)", "jinja2 (==3.1.3)", "kiwisolver (==1.4.5)", "layoutparser[layoutmodels,tesseract] (==0.3.4)", "lxml (==5.1.0)", "markdown (==3.5.2)", "markupsafe (==2.1.5)", "matplotlib (==3.7.2)", "mpmath (==1.3.0)", "msg-parser (==1.2.0)", "networkx (==3.2.1)", "numpy (==1.26.4)", "olefile (==0.47)", "omegaconf (==2.3.0)", "onnx (==1.15.0)", "onnxruntime (==1.15.1)", "opencv-python (==4.8.0.76)", "openpyxl (==3.1.2)", "packaging (==23.2)", "pandas (==2.2.0)", "pdf2image (==1.17.0)", "pdfminer-six (==20221105)", "pdfplumber (==0.10.4)", "pikepdf (==8.11.0)", "pillow (==10.2.0)", "pillow-heif (==0.15.0)", "portalocker (==2.8.2)", "protobuf (==4.23.4)", "pycocotools (==2.0.7)", "pycparser (==2.21)", "pypandoc (==1.12)", "pyparsing (==3.0.9)", "pypdf (==4.0.1)", "pypdfium2 (==4.27.0)", "pytesseract (==0.3.10)", "python-dateutil (==2.8.2)", "python-docx (==1.1.0)", "python-multipart (==0.0.9)", "python-pptx (==0.6.23)", "pytz (==2024.1)", "pyyaml (==6.0.1)", "rapidfuzz (==3.6.1)", "regex (==2023.12.25)", "requests (==2.31.0)", "safetensors (==0.3.2)", "scipy (==1.10.1)", "six (==1.16.0)", "sympy (==1.12)", "timm (==0.9.12)", "tokenizers (==0.15.2)", "torch (==2.2.0)", "torchvision (==0.17.0)", "tqdm (==4.66.2)", "transformers (==4.37.1)", "typing-extensions (==4.9.0)", "tzdata (==2024.1)", "unstructured-inference (==0.7.25)", "unstructured-pytesseract (==0.3.12)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)", "xlrd (==2.0.1)", "xlsxwriter (==3.1.9)", "zipp (==3.17.0)"]
+astra = ["anyio (==3.7.1)", "astrapy (==0.7.7)", "cassandra-driver (==3.29.0)", "cassio (==0.1.5)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "click (==8.1.7)", "deprecation (==2.1.0)", "exceptiongroup (==1.2.0)", "geomet (==0.2.1.post1)", "h11 (==0.14.0)", "h2 (==4.1.0)", "hpack (==4.0.0)", "httpcore (==1.0.4)", "httpx[http2] (==0.27.0)", "hyperframe (==6.0.1)", "idna (==3.6)", "numpy (==1.26.4)", "packaging (==23.2)", "requests (==2.31.0)", "six (==1.16.0)", "sniffio (==1.3.0)", "toml (==0.10.2)", "urllib3 (==1.26.18)"]
 azure = ["adlfs (==2024.2.0)", "aiohttp (==3.9.3)", "aiosignal (==1.3.1)", "async-timeout (==4.0.3)", "attrs (==23.2.0)", "azure-core (==1.30.0)", "azure-datalake-store (==0.0.53)", "azure-identity (==1.15.0)", "azure-storage-blob (==12.19.0)", "certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "cryptography (==42.0.2)", "frozenlist (==1.4.1)", "fsspec (==2024.2.0)", "idna (==3.6)", "isodate (==0.6.1)", "msal (==1.26.0)", "msal-extensions (==1.1.0)", "multidict (==6.0.5)", "packaging (==23.2)", "portalocker (==2.8.2)", "pycparser (==2.21)", "pyjwt[crypto] (==2.8.0)", "requests (==2.31.0)", "six (==1.16.0)", "typing-extensions (==4.9.0)", "urllib3 (==1.26.18)", "yarl (==1.9.4)"]
 azure-cognitive-search = ["azure-common (==1.1.28)", "azure-core (==1.30.0)", "azure-search-documents (==11.4.0)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "idna (==3.6)", "isodate (==0.6.1)", "requests (==2.31.0)", "six (==1.16.0)", "typing-extensions (==4.9.0)", "urllib3 (==1.26.18)"]
-bedrock = ["aiohttp (==3.9.3)", "aiosignal (==1.3.1)", "anyio (==3.7.1)", "async-timeout (==4.0.3)", "attrs (==23.2.0)", "boto3 (==1.28.17)", "botocore (==1.31.17)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "dataclasses-json (==0.6.4)", "exceptiongroup (==1.2.0)", "frozenlist (==1.4.1)", "idna (==3.6)", "jmespath (==1.0.1)", "jsonpatch (==1.33)", "jsonpointer (==2.4)", "langchain-community (==0.0.20)", "langchain-core (==0.1.23)", "langsmith (==0.0.87)", "marshmallow (==3.20.2)", "multidict (==6.0.5)", "mypy-extensions (==1.0.0)", "numpy (==1.26.4)", "packaging (==23.2)", "pydantic (==1.10.14)", "python-dateutil (==2.8.2)", "pyyaml (==6.0.1)", "requests (==2.31.0)", "s3transfer (==0.6.2)", "six (==1.16.0)", "sniffio (==1.3.0)", "sqlalchemy (==2.0.27)", "tenacity (==8.2.3)", "typing-extensions (==4.9.0)", "typing-inspect (==0.9.0)", "urllib3 (==1.26.18)", "yarl (==1.9.4)"]
+bedrock = ["aiohttp (==3.9.3)", "aiosignal (==1.3.1)", "anyio (==3.7.1)", "async-timeout (==4.0.3)", "attrs (==23.2.0)", "boto3 (==1.34.63)", "botocore (==1.34.63)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "dataclasses-json (==0.6.4)", "exceptiongroup (==1.2.0)", "frozenlist (==1.4.1)", "idna (==3.6)", "jmespath (==1.0.1)", "jsonpatch (==1.33)", "jsonpointer (==2.4)", "langchain-community (==0.0.28)", "langchain-core (==0.1.32)", "langsmith (==0.1.26)", "marshmallow (==3.20.2)", "multidict (==6.0.5)", "mypy-extensions (==1.0.0)", "numpy (==1.26.4)", "orjson (==3.9.15)", "packaging (==23.2)", "pydantic (==1.10.14)", "python-dateutil (==2.8.2)", "pyyaml (==6.0.1)", "requests (==2.31.0)", "s3transfer (==0.10.1)", "six (==1.16.0)", "sniffio (==1.3.1)", "sqlalchemy (==2.0.28)", "tenacity (==8.2.3)", "typing-extensions (==4.9.0)", "typing-inspect (==0.9.0)", "urllib3 (==1.26.18)", "yarl (==1.9.4)"]
 biomed = ["beautifulsoup4 (==4.12.3)", "bs4 (==0.0.2)", "soupsieve (==2.5)"]
 box = ["attrs (==23.2.0)", "boxfs (==0.2.1)", "boxsdk[jwt] (==3.9.2)", "certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "cryptography (==42.0.2)", "fsspec (==2024.2.0)", "idna (==3.6)", "pycparser (==2.21)", "pyjwt (==2.8.0)", "python-dateutil (==2.8.2)", "requests (==2.31.0)", "requests-toolbelt (==1.0.0)", "six (==1.16.0)", "urllib3 (==1.26.18)"]
 chroma = ["anyio (==3.7.1)", "asgiref (==3.7.2)", "backoff (==2.2.1)", "bcrypt (==4.1.2)", "build (==1.0.3)", "cachetools (==5.3.2)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "chroma-hnswlib (==0.7.3)", "chromadb (==0.4.22)", "click (==8.1.7)", "coloredlogs (==15.0.1)", "deprecated (==1.2.14)", "exceptiongroup (==1.2.0)", "fastapi (==0.109.2)", "filelock (==3.13.1)", "flatbuffers (==23.5.26)", "fsspec (==2024.2.0)", "google-auth (==2.28.0)", "googleapis-common-protos (==1.62.0)", "grpcio (==1.60.1)", "h11 (==0.14.0)", "httptools (==0.6.1)", "huggingface-hub (==0.20.3)", "humanfriendly (==10.0)", "idna (==3.6)", "importlib-metadata (==6.11.0)", "importlib-resources (==6.1.1)", "kubernetes (==29.0.0)", "mmh3 (==4.1.0)", "monotonic (==1.6)", "mpmath (==1.3.0)", "numpy (==1.26.4)", "oauthlib (==3.2.2)", "onnxruntime (==1.15.1)", "opentelemetry-api (==1.22.0)", "opentelemetry-exporter-otlp-proto-common (==1.22.0)", "opentelemetry-exporter-otlp-proto-grpc (==1.22.0)", "opentelemetry-instrumentation (==0.43b0)", "opentelemetry-instrumentation-asgi (==0.43b0)", "opentelemetry-instrumentation-fastapi (==0.43b0)", "opentelemetry-proto (==1.22.0)", "opentelemetry-sdk (==1.22.0)", "opentelemetry-semantic-conventions (==0.43b0)", "opentelemetry-util-http (==0.43b0)", "overrides (==7.7.0)", "packaging (==23.2)", "posthog (==3.4.1)", "protobuf (==4.23.4)", "pulsar-client (==3.4.0)", "pyasn1 (==0.5.1)", "pyasn1-modules (==0.3.0)", "pydantic (==1.10.14)", "pypika (==0.48.9)", "pyproject-hooks (==1.0.0)", "python-dateutil (==2.8.2)", "python-dotenv (==1.0.1)", "pyyaml (==6.0.1)", "requests (==2.31.0)", "requests-oauthlib (==1.3.1)", "rsa (==4.9)", "six (==1.16.0)", "sniffio (==1.3.0)", "starlette (==0.36.3)", "sympy (==1.12)", "tenacity (==8.2.3)", "tokenizers (==0.15.2)", "tomli (==2.0.1)", "tqdm (==4.66.2)", "typer (==0.9.0)", "typing-extensions (==4.9.0)", "urllib3 (==1.26.18)", "uvicorn[standard] (==0.27.1)", "uvloop (==0.19.0)", "watchfiles (==0.21.0)", "websocket-client (==1.7.0)", "websockets (==12.0)", "wrapt (==1.16.0)", "zipp (==3.17.0)"]
+clarifai = ["aiohttp (==3.9.3)", "aiosignal (==1.3.1)", "anyio (==3.7.1)", "async-timeout (==4.0.3)", "attrs (==23.2.0)", "beautifulsoup4 (==4.12.3)", "bs4 (==0.0.2)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "clarifai (==10.0.1)", "clarifai-grpc (==10.0.10)", "click (==8.1.7)", "contextlib2 (==21.6.0)", "dataclasses-json (==0.6.4)", "deprecated (==1.2.14)", "dirtyjson (==1.0.8)", "distro (==1.9.0)", "exceptiongroup (==1.2.0)", "frozenlist (==1.4.1)", "fsspec (==2024.2.0)", "googleapis-common-protos (==1.63.0)", "greenlet (==3.0.3)", "grpcio (==1.62.1)", "h11 (==0.14.0)", "httpcore (==1.0.4)", "httpx (==0.27.0)", "idna (==3.6)", "joblib (==1.3.2)", "llama-index (==0.10.19)", "llama-index-agent-openai (==0.1.5)", "llama-index-cli (==0.1.9)", "llama-index-core (==0.10.19)", "llama-index-embeddings-openai (==0.1.6)", "llama-index-indices-managed-llama-cloud (==0.1.4)", "llama-index-legacy (==0.9.48)", "llama-index-llms-openai (==0.1.9)", "llama-index-multi-modal-llms-openai (==0.1.4)", "llama-index-program-openai (==0.1.4)", "llama-index-question-gen-openai (==0.1.3)", "llama-index-readers-file (==0.1.9)", "llama-index-readers-llama-parse (==0.1.3)", "llama-parse (==0.3.9)", "llamaindex-py-client (==0.1.13)", "markdown-it-py (==3.0.0)", "marshmallow (==3.20.2)", "mdurl (==0.1.2)", "multidict (==6.0.5)", "mypy-extensions (==1.0.0)", "nest-asyncio (==1.6.0)", "networkx (==3.2.1)", "nltk (==3.8.1)", "numpy (==1.26.4)", "openai (==1.13.3)", "opencv-python (==4.8.0.76)", "packaging (==23.2)", "pandas (==2.2.1)", "pillow (==10.2.0)", "protobuf (==4.23.4)", "pydantic (==1.10.14)", "pygments (==2.17.2)", "pymupdf (==1.23.26)", "pymupdfb (==1.23.22)", "pypdf (==4.1.0)", "python-dateutil (==2.8.2)", "python-rapidjson (==1.16)", "pytz (==2024.1)", "pyyaml (==6.0.1)", "regex (==2023.12.25)", "requests (==2.31.0)", "rich (==13.7.1)", "schema (==0.7.5)", "six (==1.16.0)", "sniffio (==1.3.1)", "soupsieve (==2.5)", "sqlalchemy[asyncio] (==2.0.28)", "striprtf (==0.0.26)", "tenacity (==8.2.3)", "tiktoken (==0.6.0)", "tqdm (==4.66.2)", "tritonclient (==2.41.1)", "typing-extensions (==4.9.0)", "typing-inspect (==0.9.0)", "tzdata (==2024.1)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)", "yarl (==1.9.4)"]
 confluence = ["atlassian-python-api (==3.41.10)", "beautifulsoup4 (==4.12.3)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "deprecated (==1.2.14)", "idna (==3.6)", "jmespath (==1.0.1)", "oauthlib (==3.2.2)", "requests (==2.31.0)", "requests-oauthlib (==1.3.1)", "six (==1.16.0)", "soupsieve (==2.5)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)"]
 csv = ["numpy (==1.26.4)", "pandas (==2.2.0)", "python-dateutil (==2.8.2)", "pytz (==2024.1)", "six (==1.16.0)", "tzdata (==2024.1)"]
 databricks-volumes = ["cachetools (==5.3.2)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "databricks-sdk (==0.19.1)", "google-auth (==2.28.0)", "idna (==3.6)", "pyasn1 (==0.5.1)", "pyasn1-modules (==0.3.0)", "requests (==2.31.0)", "rsa (==4.9)", "urllib3 (==1.26.18)"]
@@ -7867,6 +7866,8 @@ docx = ["lxml (==5.1.0)", "python-docx (==1.1.0)", "typing-extensions (==4.9.0)"
 dropbox = ["certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "dropbox (==11.36.2)", "dropboxdrivefs (==1.3.1)", "fsspec (==2024.2.0)", "idna (==3.6)", "ply (==3.11)", "requests (==2.31.0)", "six (==1.16.0)", "stone (==3.3.1)", "urllib3 (==1.26.18)"]
 elasticsearch = ["certifi (==2024.2.2)", "elastic-transport (==8.12.0)", "elasticsearch (==8.12.0)", "urllib3 (==1.26.18)"]
 embed-huggingface = ["aiohttp (==3.9.3)", "aiosignal (==1.3.1)", "anyio (==3.7.1)", "async-timeout (==4.0.3)", "attrs (==23.2.0)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "click (==8.1.7)", "dataclasses-json (==0.6.4)", "exceptiongroup (==1.2.0)", "filelock (==3.13.1)", "frozenlist (==1.4.1)", "fsspec (==2024.2.0)", "huggingface (==0.0.1)", "huggingface-hub (==0.20.3)", "idna (==3.6)", "jinja2 (==3.1.3)", "joblib (==1.3.2)", "jsonpatch (==1.33)", "jsonpointer (==2.4)", "langchain-community (==0.0.20)", "langchain-core (==0.1.23)", "langsmith (==0.0.87)", "markupsafe (==2.1.5)", "marshmallow (==3.20.2)", "mpmath (==1.3.0)", "multidict (==6.0.5)", "mypy-extensions (==1.0.0)", "networkx (==3.2.1)", "nltk (==3.8.1)", "numpy (==1.26.4)", "packaging (==23.2)", "pillow (==10.2.0)", "pydantic (==1.10.14)", "pyyaml (==6.0.1)", "regex (==2023.12.25)", "requests (==2.31.0)", "safetensors (==0.3.2)", "scikit-learn (==1.4.0)", "scipy (==1.10.1)", "sentence-transformers (==2.3.1)", "sentencepiece (==0.1.99)", "sniffio (==1.3.0)", "sqlalchemy (==2.0.27)", "sympy (==1.12)", "tenacity (==8.2.3)", "threadpoolctl (==3.3.0)", "tokenizers (==0.15.2)", "torch (==2.2.0)", "tqdm (==4.66.2)", "transformers (==4.37.1)", "typing-extensions (==4.9.0)", "typing-inspect (==0.9.0)", "urllib3 (==1.26.18)", "yarl (==1.9.4)"]
+embed-octoai = ["anyio (==3.7.1)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "distro (==1.9.0)", "exceptiongroup (==1.2.0)", "h11 (==0.14.0)", "httpcore (==1.0.4)", "httpx (==0.27.0)", "idna (==3.6)", "openai (==1.14.3)", "pydantic (==1.10.14)", "regex (==2023.12.25)", "requests (==2.31.0)", "sniffio (==1.3.1)", "tiktoken (==0.6.0)", "tqdm (==4.66.2)", "typing-extensions (==4.10.0)", "urllib3 (==2.2.1)"]
+embed-vertexai = ["aiohttp (==3.9.3)", "aiosignal (==1.3.1)", "anyio (==3.7.1)", "async-timeout (==4.0.3)", "attrs (==23.2.0)", "cachetools (==5.3.3)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "dataclasses-json (==0.6.4)", "exceptiongroup (==1.2.0)", "frozenlist (==1.4.1)", "google-api-core[grpc] (==2.18.0)", "google-auth (==2.29.0)", "google-cloud-aiplatform (==1.44.0)", "google-cloud-bigquery (==3.19.0)", "google-cloud-core (==2.4.1)", "google-cloud-resource-manager (==1.12.3)", "google-cloud-storage (==2.16.0)", "google-crc32c (==1.5.0)", "google-resumable-media (==2.7.0)", "googleapis-common-protos[grpc] (==1.63.0)", "grpc-google-iam-v1 (==0.13.0)", "grpcio (==1.62.1)", "grpcio-status (==1.62.1)", "idna (==3.6)", "jsonpatch (==1.33)", "jsonpointer (==2.4)", "langchain (==0.1.13)", "langchain-community (==0.0.29)", "langchain-core (==0.1.33)", "langchain-google-vertexai (==0.1.1)", "langchain-text-splitters (==0.0.1)", "langsmith (==0.1.31)", "marshmallow (==3.21.1)", "multidict (==6.0.5)", "mypy-extensions (==1.0.0)", "numpy (==1.26.4)", "orjson (==3.9.15)", "packaging (==23.2)", "proto-plus (==1.23.0)", "protobuf (==4.23.4)", "pyasn1 (==0.5.1)", "pyasn1-modules (==0.3.0)", "pydantic (==1.10.14)", "python-dateutil (==2.9.0.post0)", "pyyaml (==6.0.1)", "requests (==2.31.0)", "rsa (==4.9)", "shapely (==2.0.3)", "six (==1.16.0)", "sniffio (==1.3.1)", "sqlalchemy (==2.0.29)", "tenacity (==8.2.3)", "types-protobuf (==4.24.0.20240311)", "types-requests (==2.31.0.20240311)", "typing-extensions (==4.10.0)", "typing-inspect (==0.9.0)", "urllib3 (==2.2.1)", "yarl (==1.9.4)"]
 epub = ["pypandoc (==1.12)"]
 gcs = ["aiohttp (==3.9.3)", "aiosignal (==1.3.1)", "async-timeout (==4.0.3)", "attrs (==23.2.0)", "beautifulsoup4 (==4.12.3)", "bs4 (==0.0.2)", "cachetools (==5.3.2)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "decorator (==5.1.1)", "frozenlist (==1.4.1)", "fsspec (==2024.2.0)", "gcsfs (==2024.2.0)", "google-api-core (==2.17.1)", "google-auth (==2.28.0)", "google-auth-oauthlib (==1.2.0)", "google-cloud-core (==2.4.1)", "google-cloud-storage (==2.14.0)", "google-crc32c (==1.5.0)", "google-resumable-media (==2.7.0)", "googleapis-common-protos (==1.62.0)", "idna (==3.6)", "multidict (==6.0.5)", "oauthlib (==3.2.2)", "protobuf (==4.23.4)", "pyasn1 (==0.5.1)", "pyasn1-modules (==0.3.0)", "requests (==2.31.0)", "requests-oauthlib (==1.3.1)", "rsa (==4.9)", "soupsieve (==2.5)", "urllib3 (==1.26.18)", "yarl (==1.9.4)"]
 github = ["certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "cryptography (==42.0.2)", "deprecated (==1.2.14)", "idna (==3.6)", "pycparser (==2.21)", "pygithub (==2.2.0)", "pyjwt[crypto] (==2.8.0)", "pynacl (==1.5.0)", "requests (==2.31.0)", "typing-extensions (==4.9.0)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)"]
@@ -7874,9 +7875,9 @@ gitlab = ["certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "idna (==3.6)"
 google-drive = ["cachetools (==5.3.2)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "google-api-core (==2.17.1)", "google-api-python-client (==2.118.0)", "google-auth (==2.28.0)", "google-auth-httplib2 (==0.2.0)", "googleapis-common-protos (==1.62.0)", "httplib2 (==0.22.0)", "idna (==3.6)", "protobuf (==4.23.4)", "pyasn1 (==0.5.1)", "pyasn1-modules (==0.3.0)", "pyparsing (==3.0.9)", "requests (==2.31.0)", "rsa (==4.9)", "uritemplate (==4.1.1)", "urllib3 (==1.26.18)"]
 hubspot = ["certifi (==2024.2.2)", "hubspot-api-client (==8.2.1)", "python-dateutil (==2.8.2)", "six (==1.16.0)", "urllib3 (==1.26.18)"]
 huggingface = ["certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "click (==8.1.7)", "filelock (==3.13.1)", "fsspec (==2024.2.0)", "huggingface-hub (==0.20.3)", "idna (==3.6)", "jinja2 (==3.1.3)", "joblib (==1.3.2)", "langdetect (==1.0.9)", "markupsafe (==2.1.5)", "mpmath (==1.3.0)", "networkx (==3.2.1)", "numpy (==1.26.4)", "packaging (==23.2)", "pyyaml (==6.0.1)", "regex (==2023.12.25)", "requests (==2.31.0)", "sacremoses (==0.1.1)", "safetensors (==0.3.2)", "sentencepiece (==0.1.99)", "six (==1.16.0)", "sympy (==1.12)", "tokenizers (==0.15.2)", "torch (==2.2.0)", "tqdm (==4.66.2)", "transformers (==4.37.1)", "typing-extensions (==4.9.0)", "urllib3 (==1.26.18)"]
-image = ["antlr4-python3-runtime (==4.9.3)", "certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "coloredlogs (==15.0.1)", "contourpy (==1.2.0)", "cryptography (==42.0.2)", "cycler (==0.12.1)", "deprecated (==1.2.14)", "effdet (==0.4.1)", "filelock (==3.13.1)", "flatbuffers (==23.5.26)", "fonttools (==4.49.0)", "fsspec (==2024.2.0)", "huggingface-hub (==0.20.3)", "humanfriendly (==10.0)", "idna (==3.6)", "importlib-resources (==6.1.1)", "iopath (==0.1.10)", "jinja2 (==3.1.3)", "kiwisolver (==1.4.5)", "layoutparser[layoutmodels,tesseract] (==0.3.4)", "lxml (==5.1.0)", "markupsafe (==2.1.5)", "matplotlib (==3.7.2)", "mpmath (==1.3.0)", "networkx (==3.2.1)", "numpy (==1.26.4)", "omegaconf (==2.3.0)", "onnx (==1.15.0)", "onnxruntime (==1.15.1)", "opencv-python (==4.8.0.76)", "packaging (==23.2)", "pandas (==2.2.0)", "pdf2image (==1.17.0)", "pdfminer-six (==20221105)", "pdfplumber (==0.10.4)", "pikepdf (==8.11.0)", "pillow (==10.2.0)", "pillow-heif (==0.15.0)", "portalocker (==2.8.2)", "protobuf (==4.23.4)", "pycocotools (==2.0.7)", "pycparser (==2.21)", "pyparsing (==3.0.9)", "pypdf (==4.0.1)", "pypdfium2 (==4.27.0)", "pytesseract (==0.3.10)", "python-dateutil (==2.8.2)", "python-multipart (==0.0.9)", "pytz (==2024.1)", "pyyaml (==6.0.1)", "rapidfuzz (==3.6.1)", "regex (==2023.12.25)", "requests (==2.31.0)", "safetensors (==0.3.2)", "scipy (==1.10.1)", "six (==1.16.0)", "sympy (==1.12)", "timm (==0.9.12)", "tokenizers (==0.15.2)", "torch (==2.2.0)", "torchvision (==0.17.0)", "tqdm (==4.66.2)", "transformers (==4.37.1)", "typing-extensions (==4.9.0)", "tzdata (==2024.1)", "unstructured-inference (==0.7.23)", "unstructured-pytesseract (==0.3.12)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)", "zipp (==3.17.0)"]
+image = ["antlr4-python3-runtime (==4.9.3)", "certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "coloredlogs (==15.0.1)", "contourpy (==1.2.0)", "cryptography (==42.0.2)", "cycler (==0.12.1)", "deprecated (==1.2.14)", "effdet (==0.4.1)", "filelock (==3.13.1)", "flatbuffers (==23.5.26)", "fonttools (==4.49.0)", "fsspec (==2024.2.0)", "huggingface-hub (==0.20.3)", "humanfriendly (==10.0)", "idna (==3.6)", "importlib-resources (==6.1.1)", "iopath (==0.1.10)", "jinja2 (==3.1.3)", "kiwisolver (==1.4.5)", "layoutparser[layoutmodels,tesseract] (==0.3.4)", "lxml (==5.1.0)", "markupsafe (==2.1.5)", "matplotlib (==3.7.2)", "mpmath (==1.3.0)", "networkx (==3.2.1)", "numpy (==1.26.4)", "omegaconf (==2.3.0)", "onnx (==1.15.0)", "onnxruntime (==1.15.1)", "opencv-python (==4.8.0.76)", "packaging (==23.2)", "pandas (==2.2.0)", "pdf2image (==1.17.0)", "pdfminer-six (==20221105)", "pdfplumber (==0.10.4)", "pikepdf (==8.11.0)", "pillow (==10.2.0)", "pillow-heif (==0.15.0)", "portalocker (==2.8.2)", "protobuf (==4.23.4)", "pycocotools (==2.0.7)", "pycparser (==2.21)", "pyparsing (==3.0.9)", "pypdf (==4.0.1)", "pypdfium2 (==4.27.0)", "pytesseract (==0.3.10)", "python-dateutil (==2.8.2)", "python-multipart (==0.0.9)", "pytz (==2024.1)", "pyyaml (==6.0.1)", "rapidfuzz (==3.6.1)", "regex (==2023.12.25)", "requests (==2.31.0)", "safetensors (==0.3.2)", "scipy (==1.10.1)", "six (==1.16.0)", "sympy (==1.12)", "timm (==0.9.12)", "tokenizers (==0.15.2)", "torch (==2.2.0)", "torchvision (==0.17.0)", "tqdm (==4.66.2)", "transformers (==4.37.1)", "typing-extensions (==4.9.0)", "tzdata (==2024.1)", "unstructured-inference (==0.7.25)", "unstructured-pytesseract (==0.3.12)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)", "zipp (==3.17.0)"]
 jira = ["atlassian-python-api (==3.41.10)", "beautifulsoup4 (==4.12.3)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "deprecated (==1.2.14)", "idna (==3.6)", "jmespath (==1.0.1)", "oauthlib (==3.2.2)", "requests (==2.31.0)", "requests-oauthlib (==1.3.1)", "six (==1.16.0)", "soupsieve (==2.5)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)"]
-local-inference = ["antlr4-python3-runtime (==4.9.3)", "certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "coloredlogs (==15.0.1)", "contourpy (==1.2.0)", "cryptography (==42.0.2)", "cycler (==0.12.1)", "deprecated (==1.2.14)", "effdet (==0.4.1)", "et-xmlfile (==1.1.0)", "filelock (==3.13.1)", "flatbuffers (==23.5.26)", "fonttools (==4.49.0)", "fsspec (==2024.2.0)", "huggingface-hub (==0.20.3)", "humanfriendly (==10.0)", "idna (==3.6)", "importlib-metadata (==7.0.1)", "importlib-resources (==6.1.1)", "iopath (==0.1.10)", "jinja2 (==3.1.3)", "kiwisolver (==1.4.5)", "layoutparser[layoutmodels,tesseract] (==0.3.4)", "lxml (==5.1.0)", "markdown (==3.5.2)", "markupsafe (==2.1.5)", "matplotlib (==3.7.2)", "mpmath (==1.3.0)", "msg-parser (==1.2.0)", "networkx (==3.2.1)", "numpy (==1.26.4)", "olefile (==0.47)", "omegaconf (==2.3.0)", "onnx (==1.15.0)", "onnxruntime (==1.15.1)", "opencv-python (==4.8.0.76)", "openpyxl (==3.1.2)", "packaging (==23.2)", "pandas (==2.2.0)", "pdf2image (==1.17.0)", "pdfminer-six (==20221105)", "pdfplumber (==0.10.4)", "pikepdf (==8.11.0)", "pillow (==10.2.0)", "pillow-heif (==0.15.0)", "portalocker (==2.8.2)", "protobuf (==4.23.4)", "pycocotools (==2.0.7)", "pycparser (==2.21)", "pypandoc (==1.12)", "pyparsing (==3.0.9)", "pypdf (==4.0.1)", "pypdfium2 (==4.27.0)", "pytesseract (==0.3.10)", "python-dateutil (==2.8.2)", "python-docx (==1.1.0)", "python-multipart (==0.0.9)", "python-pptx (==0.6.23)", "pytz (==2024.1)", "pyyaml (==6.0.1)", "rapidfuzz (==3.6.1)", "regex (==2023.12.25)", "requests (==2.31.0)", "safetensors (==0.3.2)", "scipy (==1.10.1)", "six (==1.16.0)", "sympy (==1.12)", "timm (==0.9.12)", "tokenizers (==0.15.2)", "torch (==2.2.0)", "torchvision (==0.17.0)", "tqdm (==4.66.2)", "transformers (==4.37.1)", "typing-extensions (==4.9.0)", "tzdata (==2024.1)", "unstructured-inference (==0.7.23)", "unstructured-pytesseract (==0.3.12)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)", "xlrd (==2.0.1)", "xlsxwriter (==3.1.9)", "zipp (==3.17.0)"]
+local-inference = ["antlr4-python3-runtime (==4.9.3)", "certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "coloredlogs (==15.0.1)", "contourpy (==1.2.0)", "cryptography (==42.0.2)", "cycler (==0.12.1)", "deprecated (==1.2.14)", "effdet (==0.4.1)", "et-xmlfile (==1.1.0)", "filelock (==3.13.1)", "flatbuffers (==23.5.26)", "fonttools (==4.49.0)", "fsspec (==2024.2.0)", "huggingface-hub (==0.20.3)", "humanfriendly (==10.0)", "idna (==3.6)", "importlib-metadata (==7.0.1)", "importlib-resources (==6.1.1)", "iopath (==0.1.10)", "jinja2 (==3.1.3)", "kiwisolver (==1.4.5)", "layoutparser[layoutmodels,tesseract] (==0.3.4)", "lxml (==5.1.0)", "markdown (==3.5.2)", "markupsafe (==2.1.5)", "matplotlib (==3.7.2)", "mpmath (==1.3.0)", "msg-parser (==1.2.0)", "networkx (==3.2.1)", "numpy (==1.26.4)", "olefile (==0.47)", "omegaconf (==2.3.0)", "onnx (==1.15.0)", "onnxruntime (==1.15.1)", "opencv-python (==4.8.0.76)", "openpyxl (==3.1.2)", "packaging (==23.2)", "pandas (==2.2.0)", "pdf2image (==1.17.0)", "pdfminer-six (==20221105)", "pdfplumber (==0.10.4)", "pikepdf (==8.11.0)", "pillow (==10.2.0)", "pillow-heif (==0.15.0)", "portalocker (==2.8.2)", "protobuf (==4.23.4)", "pycocotools (==2.0.7)", "pycparser (==2.21)", "pypandoc (==1.12)", "pyparsing (==3.0.9)", "pypdf (==4.0.1)", "pypdfium2 (==4.27.0)", "pytesseract (==0.3.10)", "python-dateutil (==2.8.2)", "python-docx (==1.1.0)", "python-multipart (==0.0.9)", "python-pptx (==0.6.23)", "pytz (==2024.1)", "pyyaml (==6.0.1)", "rapidfuzz (==3.6.1)", "regex (==2023.12.25)", "requests (==2.31.0)", "safetensors (==0.3.2)", "scipy (==1.10.1)", "six (==1.16.0)", "sympy (==1.12)", "timm (==0.9.12)", "tokenizers (==0.15.2)", "torch (==2.2.0)", "torchvision (==0.17.0)", "tqdm (==4.66.2)", "transformers (==4.37.1)", "typing-extensions (==4.9.0)", "tzdata (==2024.1)", "unstructured-inference (==0.7.25)", "unstructured-pytesseract (==0.3.12)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)", "xlrd (==2.0.1)", "xlsxwriter (==3.1.9)", "zipp (==3.17.0)"]
 md = ["importlib-metadata (==7.0.1)", "markdown (==3.5.2)", "zipp (==3.17.0)"]
 mongodb = ["dnspython (==2.5.0)", "pymongo (==4.6.1)"]
 msg = ["msg-parser (==1.2.0)", "olefile (==0.47)"]
@@ -7888,7 +7889,7 @@ opensearch = ["certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "idna (==3
 org = ["pypandoc (==1.12)"]
 outlook = ["certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "cryptography (==42.0.2)", "idna (==3.6)", "msal (==1.26.0)", "office365-rest-python-client (==2.4.2)", "pycparser (==2.21)", "pyjwt[crypto] (==2.8.0)", "pytz (==2024.1)", "requests (==2.31.0)", "urllib3 (==1.26.18)"]
 paddleocr = ["attrdict (==2.0.1)", "babel (==2.14.0)", "bce-python-sdk (==0.9.4)", "blinker (==1.7.0)", "cachetools (==5.3.2)", "certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "click (==8.1.7)", "contourpy (==1.2.0)", "cssselect (==1.2.0)", "cssutils (==2.9.0)", "cycler (==0.12.1)", "cython (==3.0.8)", "et-xmlfile (==1.1.0)", "flask (==3.0.2)", "flask-babel (==4.0.0)", "fonttools (==4.49.0)", "future (==0.18.3)", "idna (==3.6)", "imageio (==2.34.0)", "imgaug (==0.4.0)", "importlib-metadata (==7.0.1)", "importlib-resources (==6.1.1)", "itsdangerous (==2.1.2)", "jinja2 (==3.1.3)", "kiwisolver (==1.4.5)", "lanms-neo (==1.0.2)", "lazy-loader (==0.3)", "lmdb (==1.4.1)", "lxml (==5.1.0)", "markupsafe (==2.1.5)", "matplotlib (==3.7.2)", "networkx (==3.2.1)", "numpy (==1.26.4)", "opencv-contrib-python (==4.8.0.76)", "opencv-python (==4.8.0.76)", "openpyxl (==3.1.2)", "packaging (==23.2)", "pandas (==2.2.0)", "pdf2image (==1.17.0)", "pillow (==10.2.0)", "polygon3 (==3.0.9.1)", "premailer (==3.10.0)", "protobuf (==4.23.4)", "psutil (==5.9.8)", "pyclipper (==1.3.0.post5)", "pycryptodome (==3.20.0)", "pyparsing (==3.0.9)", "python-dateutil (==2.8.2)", "pytz (==2024.1)", "rapidfuzz (==3.6.1)", "rarfile (==4.1)", "requests (==2.31.0)", "scikit-image (==0.22.0)", "scipy (==1.10.1)", "shapely (==2.0.2)", "six (==1.16.0)", "tifffile (==2024.2.12)", "tqdm (==4.66.2)", "tzdata (==2024.1)", "unstructured-paddleocr (==2.6.1.3)", "urllib3 (==1.26.18)", "visualdl (==2.5.3)", "werkzeug (==3.0.1)", "zipp (==3.17.0)"]
-pdf = ["antlr4-python3-runtime (==4.9.3)", "certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "coloredlogs (==15.0.1)", "contourpy (==1.2.0)", "cryptography (==42.0.2)", "cycler (==0.12.1)", "deprecated (==1.2.14)", "effdet (==0.4.1)", "filelock (==3.13.1)", "flatbuffers (==23.5.26)", "fonttools (==4.49.0)", "fsspec (==2024.2.0)", "huggingface-hub (==0.20.3)", "humanfriendly (==10.0)", "idna (==3.6)", "importlib-resources (==6.1.1)", "iopath (==0.1.10)", "jinja2 (==3.1.3)", "kiwisolver (==1.4.5)", "layoutparser[layoutmodels,tesseract] (==0.3.4)", "lxml (==5.1.0)", "markupsafe (==2.1.5)", "matplotlib (==3.7.2)", "mpmath (==1.3.0)", "networkx (==3.2.1)", "numpy (==1.26.4)", "omegaconf (==2.3.0)", "onnx (==1.15.0)", "onnxruntime (==1.15.1)", "opencv-python (==4.8.0.76)", "packaging (==23.2)", "pandas (==2.2.0)", "pdf2image (==1.17.0)", "pdfminer-six (==20221105)", "pdfplumber (==0.10.4)", "pikepdf (==8.11.0)", "pillow (==10.2.0)", "pillow-heif (==0.15.0)", "portalocker (==2.8.2)", "protobuf (==4.23.4)", "pycocotools (==2.0.7)", "pycparser (==2.21)", "pyparsing (==3.0.9)", "pypdf (==4.0.1)", "pypdfium2 (==4.27.0)", "pytesseract (==0.3.10)", "python-dateutil (==2.8.2)", "python-multipart (==0.0.9)", "pytz (==2024.1)", "pyyaml (==6.0.1)", "rapidfuzz (==3.6.1)", "regex (==2023.12.25)", "requests (==2.31.0)", "safetensors (==0.3.2)", "scipy (==1.10.1)", "six (==1.16.0)", "sympy (==1.12)", "timm (==0.9.12)", "tokenizers (==0.15.2)", "torch (==2.2.0)", "torchvision (==0.17.0)", "tqdm (==4.66.2)", "transformers (==4.37.1)", "typing-extensions (==4.9.0)", "tzdata (==2024.1)", "unstructured-inference (==0.7.23)", "unstructured-pytesseract (==0.3.12)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)", "zipp (==3.17.0)"]
+pdf = ["antlr4-python3-runtime (==4.9.3)", "certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "coloredlogs (==15.0.1)", "contourpy (==1.2.0)", "cryptography (==42.0.2)", "cycler (==0.12.1)", "deprecated (==1.2.14)", "effdet (==0.4.1)", "filelock (==3.13.1)", "flatbuffers (==23.5.26)", "fonttools (==4.49.0)", "fsspec (==2024.2.0)", "huggingface-hub (==0.20.3)", "humanfriendly (==10.0)", "idna (==3.6)", "importlib-resources (==6.1.1)", "iopath (==0.1.10)", "jinja2 (==3.1.3)", "kiwisolver (==1.4.5)", "layoutparser[layoutmodels,tesseract] (==0.3.4)", "lxml (==5.1.0)", "markupsafe (==2.1.5)", "matplotlib (==3.7.2)", "mpmath (==1.3.0)", "networkx (==3.2.1)", "numpy (==1.26.4)", "omegaconf (==2.3.0)", "onnx (==1.15.0)", "onnxruntime (==1.15.1)", "opencv-python (==4.8.0.76)", "packaging (==23.2)", "pandas (==2.2.0)", "pdf2image (==1.17.0)", "pdfminer-six (==20221105)", "pdfplumber (==0.10.4)", "pikepdf (==8.11.0)", "pillow (==10.2.0)", "pillow-heif (==0.15.0)", "portalocker (==2.8.2)", "protobuf (==4.23.4)", "pycocotools (==2.0.7)", "pycparser (==2.21)", "pyparsing (==3.0.9)", "pypdf (==4.0.1)", "pypdfium2 (==4.27.0)", "pytesseract (==0.3.10)", "python-dateutil (==2.8.2)", "python-multipart (==0.0.9)", "pytz (==2024.1)", "pyyaml (==6.0.1)", "rapidfuzz (==3.6.1)", "regex (==2023.12.25)", "requests (==2.31.0)", "safetensors (==0.3.2)", "scipy (==1.10.1)", "six (==1.16.0)", "sympy (==1.12)", "timm (==0.9.12)", "tokenizers (==0.15.2)", "torch (==2.2.0)", "torchvision (==0.17.0)", "tqdm (==4.66.2)", "transformers (==4.37.1)", "typing-extensions (==4.9.0)", "tzdata (==2024.1)", "unstructured-inference (==0.7.25)", "unstructured-pytesseract (==0.3.12)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)", "zipp (==3.17.0)"]
 pinecone = ["certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "dnspython (==2.5.0)", "idna (==3.6)", "loguru (==0.7.2)", "numpy (==1.26.4)", "pinecone-client (==2.2.4)", "python-dateutil (==2.8.2)", "pyyaml (==6.0.1)", "requests (==2.31.0)", "six (==1.16.0)", "tqdm (==4.66.2)", "typing-extensions (==4.9.0)", "urllib3 (==1.26.18)"]
 postgres = ["psycopg2-binary (==2.9.9)"]
 ppt = ["lxml (==5.1.0)", "pillow (==10.2.0)", "python-pptx (==0.6.23)", "xlsxwriter (==3.1.9)"]
@@ -7897,7 +7898,7 @@ qdrant = ["anyio (==3.7.1)", "certifi (==2024.2.2)", "exceptiongroup (==1.2.0)",
 reddit = ["certifi (==2024.2.2)", "charset-normalizer (==3.3.2)", "idna (==3.6)", "praw (==7.7.1)", "prawcore (==2.4.0)", "requests (==2.31.0)", "update-checker (==0.18.0)", "urllib3 (==1.26.18)", "websocket-client (==1.7.0)"]
 rst = ["pypandoc (==1.12)"]
 rtf = ["pypandoc (==1.12)"]
-s3 = ["aiobotocore (==2.7.0)", "aiohttp (==3.9.3)", "aioitertools (==0.11.0)", "aiosignal (==1.3.1)", "async-timeout (==4.0.3)", "attrs (==23.2.0)", "botocore (==1.31.17)", "frozenlist (==1.4.1)", "fsspec (==2024.2.0)", "idna (==3.6)", "jmespath (==1.0.1)", "multidict (==6.0.5)", "python-dateutil (==2.8.2)", "s3fs (==2024.2.0)", "six (==1.16.0)", "typing-extensions (==4.9.0)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)", "yarl (==1.9.4)"]
+s3 = ["aiobotocore (==2.12.1)", "aiohttp (==3.9.3)", "aioitertools (==0.11.0)", "aiosignal (==1.3.1)", "async-timeout (==4.0.3)", "attrs (==23.2.0)", "botocore (==1.34.51)", "frozenlist (==1.4.1)", "fsspec (==2024.2.0)", "idna (==3.6)", "jmespath (==1.0.1)", "multidict (==6.0.5)", "python-dateutil (==2.8.2)", "s3fs (==2024.2.0)", "six (==1.16.0)", "typing-extensions (==4.9.0)", "urllib3 (==1.26.18)", "wrapt (==1.16.0)", "yarl (==1.9.4)"]
 salesforce = ["attrs (==23.2.0)", "certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "cryptography (==42.0.2)", "idna (==3.6)", "isodate (==0.6.1)", "lxml (==5.1.0)", "more-itertools (==10.2.0)", "pendulum (==3.0.0)", "platformdirs (==3.10.0)", "pycparser (==2.21)", "pyjwt (==2.8.0)", "python-dateutil (==2.8.2)", "pytz (==2024.1)", "requests (==2.31.0)", "requests-file (==2.0.0)", "requests-toolbelt (==1.0.0)", "simple-salesforce (==1.12.5)", "six (==1.16.0)", "time-machine (==2.13.0)", "tzdata (==2024.1)", "urllib3 (==1.26.18)", "zeep (==4.2.1)"]
 sftp = ["bcrypt (==4.1.2)", "cffi (==1.16.0)", "cryptography (==42.0.2)", "fsspec (==2024.2.0)", "paramiko (==3.4.0)", "pycparser (==2.21)", "pynacl (==1.5.0)"]
 sharepoint = ["certifi (==2024.2.2)", "cffi (==1.16.0)", "charset-normalizer (==3.3.2)", "cryptography (==42.0.2)", "idna (==3.6)", "msal (==1.26.0)", "office365-rest-python-client (==2.4.2)", "pycparser (==2.21)", "pyjwt[crypto] (==2.8.0)", "pytz (==2024.1)", "requests (==2.31.0)", "urllib3 (==1.26.18)"]
@@ -7939,13 +7940,13 @@ dev = ["pylint (==2.16.2)"]
 
 [[package]]
 name = "unstructured-inference"
-version = "0.7.23"
+version = "0.7.25"
 description = "A library for performing inference using trained models."
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "unstructured_inference-0.7.23-py3-none-any.whl", hash = "sha256:f47d7e88dfcac910c5ad57580b132d0fe09d90e3a03908958621109f755e7f3e"},
-    {file = "unstructured_inference-0.7.23.tar.gz", hash = "sha256:b9cf691503accc78190c9a2bd65c446c870dc6936bbd93ba638807e9a69602fb"},
+    {file = "unstructured_inference-0.7.25-py3-none-any.whl", hash = "sha256:f168532db0aa6c00868d5cb3e763b20e21c27f347b858c84744c1a6459ed0505"},
+    {file = "unstructured_inference-0.7.25.tar.gz", hash = "sha256:c886c2badd833cc192ffefc2f84a6240958bea4fc1c6d8cb8a354a22713c7240"},
 ]
 
 [package.dependencies]
@@ -8387,4 +8388,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "9260d38e0fe9c86d3b4046583f7f10cb88e94bafc8da7104293f0c48d6130de6"
+content-hash = "8ae103e11919f0b27a5dda5f7ef4f61f6c87a0407b401dd2aa7f1765a0765062"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ sentence-transformers = "^2.6.0"
 pika = "^1.3.2"
 
 [tool.poetry.group.ingester.dependencies]
-unstructured = {version = "<0.13.0", extras = ["all-docs"]}  # v13 doesn't automatically handle pdfs
+unstructured = {version = "0.13.0", extras = ["all-docs"]}
 opencv-python-headless = "^4.9.0.80"
 sentence-transformers = "^2.6.0"
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -17,7 +17,7 @@ def test_upload_to_elastic(file_pdf_path):
     assert response.status_code == 200
     file_uuid = response.json()["uuid"]
 
-    timeout = 60  # 10s should be plenty
+    timeout = 120  # 10s should be plenty
     start_time = time.time()
     embeddings_found = False
     error = ""


### PR DESCRIPTION
## Context

unstructured v0.13 has some undocumented breaking change that is breaking the integration tests.

## Changes proposed in this pull request

Following guidance in the error messages I have added:
* `poppler-utils`
* `tesseract-ocr`

To the `ingester` `Dockerfile`


 
## Guidance to review

*Note* the ingester now appears to be doing a lot more work, and takes a lot longer to do it (I had to bump the timeout to 2 minutes)

```
ingester-1  | INFO:root:Ingesting file: uuid=UUID('3220275a-49d6-42cd-85c1-c60af674166f') created_datetime=datetime.datetime(2024, 4, 3, 8, 20, 47, 903457) creator_user_uuid=None url=Url('http://minio:9000/redbox-storage-dev/Cabinet%20Office%20-%20Wikipedia.pdf') content_type=<ContentType.PDF: 'pdf'> name='Cabinet Office - Wikipedia.pdf' text=None processing_status=<ProcessingStatusEnum.parsing: 'parsing'> model_type='File' text_hash='d41d8cd98f00b204e9800998ecf8427e' token_count=0
ingester-1  | INFO:elastic_transport.transport:PUT http://elasticsearch:9200/redbox-data-file/_doc/3220275a-49d6-42cd-85c1-c60af674166f [status:200 duration:0.014s]
ingester-1  | WARNING:unstructured:This function will be deprecated in a future release and `unstructured` will simply use the DEFAULT_MODEL from `unstructured_inference.model.base` to set default model name
ingester-1  | INFO:unstructured_inference:Reading PDF for file: /tmp/tmphcicikr_ ...
ingester-1  | INFO:unstructured_inference:Detecting page elements ...
ingester-1  | INFO:unstructured_inference:Detecting page elements ...
ingester-1  | INFO:unstructured_inference:Detecting page elements ...
ingester-1  | INFO:unstructured_inference:Detecting page elements ...
ingester-1  | INFO:unstructured_inference:Detecting page elements ...
ingester-1  | INFO:unstructured_inference:Detecting page elements ...
ingester-1  | INFO:unstructured:Processing entire page OCR with tesseract...
ingester-1  | INFO:unstructured:Processing entire page OCR with tesseract...
ingester-1  | INFO:unstructured_inference:padding image by 20 for structure detection
ingester-1  | INFO:unstructured:Processing entire page OCR with tesseract...
ingester-1  | INFO:unstructured:Processing entire page OCR with tesseract...
ingester-1  | INFO:unstructured:Processing entire page OCR with tesseract...
ingester-1  | INFO:unstructured_inference:padding image by 20 for structure detection
ingester-1  | INFO:unstructured:Processing entire page OCR with tesseract...
ingester-1  | INFO:unstructured:Processing entire page OCR with tesseract...
ingester-1  | INFO:unstructured_inference:padding image by 20 for structure detection
ingester-1  | INFO:unstructured:Processing entire page OCR with tesseract...
ingester-1  | INFO:unstructured_inference:padding image by 20 for structure detection
ingester-1  | INFO:unstructured:Processing entire page OCR with tesseract...
ingester-1  | INFO:unstructured:Processing entire page OCR with tesseract...
Batches: 100%|██████████| 2/2 [00:04<00:00,  2.19s/it]

```

but, [integration tests are passing
](https://github.com/i-dot-ai/redbox-copilot/actions/runs/8535585799)

## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-135

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
