### PR TITLE
deleting chunks from elasticsearch

### DIFF
--- a/core_api/src/app.py
+++ b/core_api/src/app.py
@@ -169,7 +169,9 @@ def delete_file(file_uuid: UUID) -> File:
     file = storage_handler.read_item(file_uuid, model_type="File")
     s3.delete_object(Bucket=env.bucket_name, Key=file.name)
     storage_handler.delete_item(file)
-    storage_handler.delete_file_chunks(file_uuid)
+
+    chunks = storage_handler.get_file_chunks(file.uuid)
+    storage_handler.delete_items(chunks)
     return file
 
 

--- a/core_api/src/app.py
+++ b/core_api/src/app.py
@@ -169,6 +169,7 @@ def delete_file(file_uuid: UUID) -> File:
     file = storage_handler.read_item(file_uuid, model_type="File")
     s3.delete_object(Bucket=env.bucket_name, Key=file.name)
     storage_handler.delete_item(file_uuid, model_type="File")
+    storage_handler.delete_file_chunks(file_uuid)
     return file
 
 

--- a/core_api/src/app.py
+++ b/core_api/src/app.py
@@ -168,7 +168,7 @@ def delete_file(file_uuid: UUID) -> File:
     """
     file = storage_handler.read_item(file_uuid, model_type="File")
     s3.delete_object(Bucket=env.bucket_name, Key=file.name)
-    storage_handler.delete_item(file_uuid, model_type="File")
+    storage_handler.delete_item(file)
     storage_handler.delete_file_chunks(file_uuid)
     return file
 
@@ -186,7 +186,7 @@ async def ingest_file(file_uuid: UUID) -> File:
     file = storage_handler.read_item(file_uuid, model_type="File")
 
     file.processing_status = ProcessingStatusEnum.parsing
-    storage_handler.update_item(item_uuid=file.uuid, item=file)
+    storage_handler.update_item(item=file)
 
     log.info(f"publishing {file.uuid}")
     await publisher.publish(file)

--- a/core_api/tests/conftest.py
+++ b/core_api/tests/conftest.py
@@ -85,16 +85,16 @@ def file(s3_client, file_pdf_path) -> YieldFixture[File]:
 @pytest.fixture
 def stored_file(elasticsearch_storage_handler, file) -> YieldFixture[File]:
     elasticsearch_storage_handler.write_item(file)
+    elasticsearch_storage_handler.refresh()
     yield file
 
 
 @pytest.fixture
 def chunked_file(elasticsearch_storage_handler, stored_file) -> YieldFixture[File]:
     for i in range(5):
-        chunk = Chunk(
-            text="hello", index=i, parent_file_uuid=stored_file.uuid, metadata={}
-        )
+        chunk = Chunk(text="hello", index=i, parent_file_uuid=stored_file.uuid, metadata={})
         elasticsearch_storage_handler.write_item(chunk)
+    elasticsearch_storage_handler.refresh()
     yield stored_file
 
 

--- a/core_api/tests/test_app.py
+++ b/core_api/tests/test_app.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 from elasticsearch import NotFoundError
 from faststream.redis import TestRedisBroker
@@ -60,10 +58,12 @@ def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, chunk
     # check assets exist
     assert s3_client.get_object(Bucket=env.bucket_name, Key=chunked_file.name)
     assert elasticsearch_storage_handler.read_item(item_uuid=chunked_file.uuid, model_type="file")
-    assert not elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid)
+    assert elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid)
 
     response = app_client.delete(f"/file/{chunked_file.uuid}")
     assert response.status_code == 200
+
+    elasticsearch_storage_handler.refresh()
 
     # check assets dont exist
     with pytest.raises(Exception):
@@ -143,8 +143,6 @@ def test_embed_sentences(client):
 
 
 def test_get_file_chunks(client, chunked_file):
-    # TODO: fix this hack
-    time.sleep(1)
     response = client.get(f"/file/{chunked_file.uuid}/chunks")
     assert response.status_code == 200
     assert len(response.json()) == 5

--- a/core_api/tests/test_app.py
+++ b/core_api/tests/test_app.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from elasticsearch import NotFoundError
 from faststream.redis import TestRedisBroker

--- a/core_api/tests/test_app.py
+++ b/core_api/tests/test_app.py
@@ -19,9 +19,7 @@ def test_get_health(app_client):
 
 
 @pytest.mark.asyncio
-async def test_post_file_upload(
-    s3_client, app_client, elasticsearch_storage_handler, file_pdf_path
-):
+async def test_post_file_upload(s3_client, app_client, elasticsearch_storage_handler, file_pdf_path):
     """
     Given a new file
     When I POST it to /file
@@ -31,9 +29,7 @@ async def test_post_file_upload(
         async with TestRedisBroker(router.broker):
             response = app_client.post("/file", files={"file": ("filename", f, "pdf")})
     assert response.status_code == 200
-    assert s3_client.get_object(
-        Bucket=env.bucket_name, Key=file_pdf_path.split("/")[-1]
-    )
+    assert s3_client.get_object(Bucket=env.bucket_name, Key=file_pdf_path.split("/")[-1])
     json_response = response.json()
     assert (
         elasticsearch_storage_handler.read_item(
@@ -55,29 +51,28 @@ def test_get_file(app_client, stored_file):
     assert response.status_code == 200
 
 
-def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, stored_file):
+def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, chunked_file):
     """
     Given a previously saved file
     When I DELETE it to /file
-    I Expect to see it removed from s3 and elastic-search
+    I Expect to see it removed from s3 and elastic-search, including the chunks
     """
     # check assets exist
-    assert s3_client.get_object(Bucket=env.bucket_name, Key=stored_file.name)
-    assert elasticsearch_storage_handler.read_item(
-        item_uuid=stored_file.uuid, model_type="file"
-    )
+    assert s3_client.get_object(Bucket=env.bucket_name, Key=chunked_file.name)
+    assert elasticsearch_storage_handler.read_item(item_uuid=chunked_file.uuid, model_type="file")
+    assert not elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid)
 
-    response = app_client.delete(f"/file/{stored_file.uuid}")
+    response = app_client.delete(f"/file/{chunked_file.uuid}")
     assert response.status_code == 200
 
     # check assets dont exist
     with pytest.raises(Exception):
-        s3_client.get_object(Bucket=env.bucket_name, Key=stored_file.name)
+        s3_client.get_object(Bucket=env.bucket_name, Key=chunked_file.name)
 
     with pytest.raises(NotFoundError):
-        elasticsearch_storage_handler.read_item(
-            item_uuid=stored_file.uuid, model_type="file"
-        )
+        elasticsearch_storage_handler.read_item(item_uuid=chunked_file.uuid, model_type="file")
+
+    assert not elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid)
 
 
 @pytest.mark.asyncio

--- a/embedder/src/worker.py
+++ b/embedder/src/worker.py
@@ -52,7 +52,7 @@ async def embed(
         )
         return
     chunk.embedding = embedded_sentences.data[0].embedding
-    storage_handler.update_item(chunk.uuid, chunk)
+    storage_handler.update_item(chunk)
 
 
 app = FastStream(broker, lifespan=lifespan)

--- a/ingester/src/worker.py
+++ b/ingester/src/worker.py
@@ -60,7 +60,7 @@ async def ingest(
     )
 
     file.processing_status = ProcessingStatusEnum.chunking
-    storage_handler.update_item(file.uuid, file)
+    storage_handler.update_item(file)
 
     chunks = chunker.chunk_file(
         file=file,

--- a/redbox/storage/elasticsearch.py
+++ b/redbox/storage/elasticsearch.py
@@ -51,9 +51,7 @@ class ElasticsearchStorageHandler(BaseStorageHandler):
 
     def read_items(self, item_uuids: list[UUID], model_type: str):
         target_index = f"{self.root_index}-{model_type.lower()}"
-        result = self.es_client.mget(
-            index=target_index, body={"ids": list(map(str, item_uuids))}
-        )
+        result = self.es_client.mget(index=target_index, body={"ids": list(map(str, item_uuids))})
 
         model = self.get_model_by_model_type(model_type)
         items = [model(**item["_source"]) for item in result.body["docs"]]
@@ -141,3 +139,13 @@ class ElasticsearchStorageHandler(BaseStorageHandler):
             )
         ]
         return res
+
+    def delete_file_chunks(self, parent_file_uuid: UUID):
+        """delete chunks for a given file"""
+        target_index = f"{self.root_index}-chunk"
+
+        result = self.es_client.delete_by_query(
+            index=target_index,
+            body={"query": {"match": {"parent_file_uuid": str(parent_file_uuid)}}},
+        )
+        return result

--- a/redbox/storage/elasticsearch.py
+++ b/redbox/storage/elasticsearch.py
@@ -136,7 +136,7 @@ class ElasticsearchStorageHandler(BaseStorageHandler):
         target_index = f"{self.root_index}-chunk"
 
         res = [
-            item["_source"]
+            Chunk(**item["_source"])
             for item in scan(
                 client=self.es_client,
                 index=target_index,
@@ -145,14 +145,3 @@ class ElasticsearchStorageHandler(BaseStorageHandler):
         ]
         return res
 
-    def delete_file_chunks(self, parent_file_uuid: UUID):
-        """delete chunks for a given file"""
-        target_index = f"{self.root_index}-chunk"
-
-        chunks = self.get_file_chunks(parent_file_uuid)
-
-        result = self.es_client.delete_by_query(
-            index=target_index,
-            body={"query": {"terms": {"_id": [str(chunk.uuid) for chunk in chunks]}}},
-        )
-        return result

--- a/redbox/storage/elasticsearch.py
+++ b/redbox/storage/elasticsearch.py
@@ -149,8 +149,10 @@ class ElasticsearchStorageHandler(BaseStorageHandler):
         """delete chunks for a given file"""
         target_index = f"{self.root_index}-chunk"
 
+        chunks = self.get_file_chunks(parent_file_uuid)
+
         result = self.es_client.delete_by_query(
             index=target_index,
-            body={"query": {"match": {"parent_file_uuid": str(parent_file_uuid)}}},
+            body={"query": {"terms": {"_id": [str(chunk.uuid) for chunk in chunks]}}},
         )
         return result

--- a/redbox/storage/storage_handler.py
+++ b/redbox/storage/storage_handler.py
@@ -14,10 +14,7 @@ class BaseStorageHandler(ABC):
     """
 
     # dict comprehension for lowercase class name to class
-    model_type_map = {
-        v.__name__.lower(): v
-        for v in [Chunk, Collection, Feedback, File, SpotlightComplete]
-    }
+    model_type_map = {v.__name__.lower(): v for v in [Chunk, Collection, Feedback, File, SpotlightComplete]}
 
     def get_model_by_model_type(self, model_type):
         return self.model_type_map[model_type.lower()]

--- a/redbox/storage/storage_handler.py
+++ b/redbox/storage/storage_handler.py
@@ -45,22 +45,22 @@ class BaseStorageHandler(ABC):
         pass
 
     @abstractmethod
-    def update_item(self, item_uuid: UUID, item: PersistableModel):
+    def update_item(self, item: PersistableModel):
         """Update an object in a data store"""
         pass
 
     @abstractmethod
-    def update_items(self, item_uuids: list[UUID], items: list[PersistableModel]):
+    def update_items(self, items: list[PersistableModel]):
         """Update a list of objects in a data store"""
         pass
 
     @abstractmethod
-    def delete_item(self, item_uuid: UUID, model_type: str):
+    def delete_item(self, item: PersistableModel):
         """Delete an object from a data store"""
         pass
 
     @abstractmethod
-    def delete_items(self, item_uuids: list[UUID], model_type: str):
+    def delete_items(self, items: list[PersistableModel]):
         """Delete a list of objects from a data store"""
         pass
 

--- a/redbox/tests/conftest.py
+++ b/redbox/tests/conftest.py
@@ -27,6 +27,17 @@ def chunk() -> Chunk:
 
 
 @pytest.fixture
+def another_chunk() -> Chunk:
+    test_chunk = Chunk(
+        parent_file_uuid=uuid4(),
+        index=1,
+        text="test_text",
+        metadata={},
+    )
+    return test_chunk
+
+
+@pytest.fixture
 def stored_chunk(elasticsearch_storage_handler, chunk) -> Chunk:
     elasticsearch_storage_handler.write_item(item=chunk)
     return chunk

--- a/redbox/tests/storage/test_elasticsearch.py
+++ b/redbox/tests/storage/test_elasticsearch.py
@@ -122,13 +122,13 @@ def test_elastic_write_read_delete_items(elasticsearch_storage_handler):
 
     assert read_chunks == chunks
 
-    chunk_uuids_to_delete = [chunk.uuid for chunk in chunks]
     # Delete the chunks
-    elasticsearch_storage_handler.delete_items(chunk_uuids_to_delete, "Chunk")
+    elasticsearch_storage_handler.delete_items(chunks)
 
     # Check that the chunks are deleted
     items_left = elasticsearch_storage_handler.list_all_items("Chunk")
-    assert chunk_uuids_to_delete not in items_left
+
+    assert all(chunk.uuid not in items_left for chunk in chunks)
 
 
 @pytest.mark.xfail(reason="")
@@ -150,7 +150,7 @@ def test_elastic_delete_item(elasticsearch_storage_handler, stored_chunk):
     When I call delete_item on it
     Then I expect to not be able to read the item
     """
-    elasticsearch_storage_handler.delete_item(stored_chunk.uuid, "Chunk")
+    elasticsearch_storage_handler.delete_item(stored_chunk)
 
     with pytest.raises(NotFoundError):
         elasticsearch_storage_handler.read_item(stored_chunk.uuid, "Chunk")

--- a/redbox/tests/storage/test_elasticsearch.py
+++ b/redbox/tests/storage/test_elasticsearch.py
@@ -75,6 +75,7 @@ def test_elastic_read_item(elasticsearch_storage_handler, stored_chunk):
 
 def test_elastic_delete_item_fail(
     elasticsearch_storage_handler: ElasticsearchStorageHandler,
+    another_chunk,
 ):
     """
     Given that I have an non-existent item uuid
@@ -82,7 +83,7 @@ def test_elastic_delete_item_fail(
     Then I expect to see a NotFoundError error raised
     """
     with pytest.raises(NotFoundError):
-        elasticsearch_storage_handler.delete_item(uuid4(), "Chunk")
+        elasticsearch_storage_handler.delete_item(another_chunk)
 
 
 def test_elastic_read_item_fail(


### PR DESCRIPTION
## Context

As a User I want `DELETE: /file/{file_uuid}` to delete all artefacts associated with my file.

## Changes proposed in this pull request

1. `DELETE: /file/{file_uuid}` now deletes the file-chunks from elasticsearch as well as the original file
2. the corresponding test checks that file-chunks exist before deletion and not afterwards
3. I have added a `refresh` method to the elasticsearch handler to to address a long standing issue we have had with elastics refresh rate https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html#:~:text=By%20default%2C%20Elasticsearch%20periodically%20refreshes,refresh_interval%20setting. 
4. I have tidied up the `redbox/storage` so that it is sufficient to pass the object to be deleted/updated and not its model-name & uuid 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-79


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/8538090826
