### PR TITLE
Added dependabot changes to github checks

### DIFF
--- a/.github/workflows/django-checks.yml
+++ b/.github/workflows/django-checks.yml
@@ -16,6 +16,7 @@ on:
       - 'bugfix/**'
       - 'hotfix/**'
       - 'develop'
+      - 'dependabot/**'
   workflow_dispatch:
 
 

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,6 +11,7 @@ on:
       - core_api/**
       - ingester/**
       - Makefile
+      - poetry.lock
       - .github/**
     branches:
       - 'main'


### PR DESCRIPTION
## Context

Dependabot branches aren't in checks, and the routinely edited file `poetry.lock` isn't either. Adding these allows the checks to run on dependabot changes to validate version changes haven't broken anything.

## Changes proposed in this pull request

- Updated django-checks.yml
- Updated python-app.yml

## Guidance to review

N/A
