### PR TITLE
feature/simplify-ingester

### DIFF
--- a/core_api/src/app.py
+++ b/core_api/src/app.py
@@ -114,17 +114,19 @@ async def create_upload_file(name: str, type: str, location: AnyHttpUrl) -> uuid
         UUID: The file uuid from the elastic database
     """
 
-    file_record = File(
+    file = File(
         name=name,
         url=str(location),  # avoids JSON serialisation error
         content_type=type,
     )
 
-    storage_handler.write_item(file_record)
+    storage_handler.write_item(file)
 
-    await ingest_file(file_record.uuid)
+    log.info(f"publishing {file.uuid}")
+    await publisher.publish(file)
 
-    return file_record.uuid
+
+    return file.uuid
 
 
 @app.get("/file/{file_uuid}", response_model=File, tags=["file"])
@@ -156,24 +158,6 @@ def delete_file(file_uuid: UUID) -> File:
 
     chunks = storage_handler.get_file_chunks(file.uuid)
     storage_handler.delete_items(chunks)
-    return file
-
-
-@app.post("/file/{file_uuid}/ingest", response_model=File, tags=["file"])
-async def ingest_file(file_uuid: UUID) -> File:
-    """Trigger the ingest process for a file to a queue.
-
-    Args:
-        file_uuid (UUID): The UUID of the file to ingest
-
-    Returns:
-        File: The file that was ingested
-    """
-    file = storage_handler.read_item(file_uuid, model_type="File")
-
-    log.info(f"publishing {file.uuid}")
-    await publisher.publish(file)
-
     return file
 
 

--- a/core_api/src/app.py
+++ b/core_api/src/app.py
@@ -1,7 +1,6 @@
 import logging
 import uuid
 from datetime import datetime
-from email.policy import HTTP
 from uuid import UUID
 
 from fastapi import FastAPI, HTTPException
@@ -102,10 +101,8 @@ def health():
     return output
 
 
-@app.post("/file", response_model=uuid.UUID, tags=["file"])
-async def create_upload_file(
-    name: str, type: str, location: AnyHttpUrl, ingest=True
-) -> uuid.UUID:
+@app.post("/file", tags=["file"])
+async def create_upload_file(name: str, type: str, location: AnyHttpUrl) -> uuid.UUID:
     """Upload a file to the object store and create a record in the database
 
     Args:
@@ -125,8 +122,7 @@ async def create_upload_file(
 
     storage_handler.write_item(file_record)
 
-    if ingest:
-        await ingest_file(file_record.uuid)
+    await ingest_file(file_record.uuid)
 
     return file_record.uuid
 
@@ -199,7 +195,7 @@ def get_file_status(file_uuid: UUID) -> FileStatus:
     """
     try:
         status = storage_handler.get_file_status(file_uuid)
-    except ValueError as exc:
+    except ValueError:
         raise HTTPException(status_code=404, detail=f"File {file_uuid} not found")
 
     return status

--- a/core_api/tests/test_app.py
+++ b/core_api/tests/test_app.py
@@ -4,7 +4,7 @@ import pytest
 from elasticsearch import NotFoundError
 from faststream.redis import TestRedisBroker
 
-from core_api.src.app import env, publisher, router
+from core_api.src.app import env, router
 
 
 def test_get_health(app_client):
@@ -27,16 +27,15 @@ async def test_post_file_upload(
     I Expect to see it persisted in elastic-search
     """
 
-    file_name = os.path.basename(file_pdf_path)
+    file_key = os.path.basename(file_pdf_path)
 
     with open(file_pdf_path, "rb") as f:
-        file_key = "filename.pdf"
 
         s3_client.upload_fileobj(
             Bucket=env.bucket_name,
             Fileobj=f,
             Key=file_key,
-            ExtraArgs={"Tagging": f"file_type=pdf"},
+            ExtraArgs={"Tagging": "file_type=pdf"},
         )
 
         authenticated_s3_url = s3_client.generate_presigned_url(

--- a/core_api/tests/test_app.py
+++ b/core_api/tests/test_app.py
@@ -100,21 +100,6 @@ def test_delete_file(
     assert not elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid)
 
 
-@pytest.mark.asyncio
-async def test_ingest_file(app_client, stored_file, elasticsearch_storage_handler):
-    """
-    Given a previously saved file
-    When I POST to /file/uuid/ingest
-    I Expect to see a message on the ingester-queue, THIS IS NOT WORKING
-    """
-    async with TestRedisBroker(router.broker):
-        response = app_client.post(f"/file/{stored_file.uuid}/ingest/")
-
-        assert response.status_code == 200
-
-        publisher.mock.called_once_with(stored_file)
-
-
 def test_read_model(client):
     """
     Given that I have a model in the database

--- a/redbox/parsing/chunkers.py
+++ b/redbox/parsing/chunkers.py
@@ -1,16 +1,20 @@
-from typing import Optional
-from uuid import UUID
-
 from unstructured.chunking.title import chunk_by_title
 from unstructured.partition.auto import partition
 
-from redbox.models import Chunk, File
+from redbox.models import Chunk, File, Settings
+
+env = Settings()
+s3_client = env.s3_client()
 
 
-def other_chunker(
-    file: File
-) -> list[Chunk]:
-    elements = partition(url=str(file.url))
+def other_chunker(file: File) -> list[Chunk]:
+    authenticated_s3_url = s3_client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": env.bucket_name, "Key": file.name},
+        ExpiresIn=3600,
+    )
+
+    elements = partition(url=authenticated_s3_url)
     raw_chunks = chunk_by_title(elements=elements)
 
     chunks = []

--- a/redbox/parsing/chunkers.py
+++ b/redbox/parsing/chunkers.py
@@ -8,9 +8,9 @@ from redbox.models import Chunk, File
 
 
 def other_chunker(
-    file: File, file_url: str, creator_user_uuid: Optional[UUID] = None
+    file: File
 ) -> list[Chunk]:
-    elements = partition(url=file_url)
+    elements = partition(url=str(file.url))
     raw_chunks = chunk_by_title(elements=elements)
 
     chunks = []
@@ -23,7 +23,7 @@ def other_chunker(
             index=i,
             text=raw_chunk["text"],
             metadata=raw_chunk["metadata"],
-            creator_user_uuid=creator_user_uuid,
+            creator_user_uuid=file.creator_user_uuid,
         )
         chunks.append(chunk)
 

--- a/redbox/parsing/file_chunker.py
+++ b/redbox/parsing/file_chunker.py
@@ -20,9 +20,7 @@ class FileChunker:
     def chunk_file(
         self,
         file: File,
-        file_url: str,
         chunk_clustering: bool = True,
-        creator_user_uuid: Optional[UUID] = None,
     ) -> list[Chunk]:
         """_summary_
 
@@ -37,7 +35,7 @@ class FileChunker:
         Returns:
             List[Chunk]: The chunks generated from the given file.
         """
-        chunks = other_chunker(file, file_url, creator_user_uuid=creator_user_uuid)
+        chunks = other_chunker(file)
 
         if chunk_clustering:
             chunks = cluster_chunks(chunks, embedding_model=self.embedding_model)

--- a/streamlit_app/pages/1_Add_Documents.py
+++ b/streamlit_app/pages/1_Add_Documents.py
@@ -108,11 +108,7 @@ if submitted:  # noqa: C901
 
         with st.spinner(f"Chunking **{file.name}**"):
             try:
-                chunks = file_chunker.chunk_file(
-                    file=file,
-                    file_url=authenticated_s3_url,
-                    creator_user_uuid=st.session_state.user_uuid,
-                )
+                chunks = file_chunker.chunk_file(file=file)
             except TypeError as err:
                 st.error(f"Failed to chunk {file.name}, error: {str(err)}")
                 st.write(file.model_dump())


### PR DESCRIPTION
## Context

We can simplify the ingester.

## Changes proposed in this pull request

* I have made better use of the `File` object so that we do not need to pass around so many individual variables
* this means that we no longer need to get the same data (twice) from s3 in the ingester


## Guidance to review

- [ ] Does CI pass, including the integration tests?

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/8615444109
