### PR TITLE
feature/improve-integration-test-notifications

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -65,21 +65,21 @@ jobs:
         pip install boto3
         python -m pytest tests
 
-    - name: notify slack
-      id: slack
+    - name: notify slack failure
+      id: slack failure
       uses: slackapi/slack-github-action@v1.24.0
-      if: ${{ failure() }}
+      if: ${{ failure() && github.event_name == 'schedule' }}
       with:
         channel-id: 'C05D67P6M34'
         payload: |
           {
-            "text": "Integration Tests Failed",
+            "text": "Scheduled Integration Tests Failed",
             "blocks": [
               {
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": "integration tests are failing :alert:"
+                  "text": "Scheduled integration tests are failing :alert:"
                 }
               },
               {
@@ -97,6 +97,29 @@ jobs:
                     "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                   }
                 ]
+              }
+            ]
+          }
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_TOKEN }}
+        SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+    - name: notify slack pass
+      id: slack pass
+      uses: slackapi/slack-github-action@v1.24.0
+      if: ${{ success() && github.event_name == 'schedule' }}
+      with:
+        channel-id: 'C05D67P6M34'
+        payload: |
+          {
+            "text": "Scheduled Integration Tests Passed",
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "Scheduled integration tests are passing :white_check_mark:"
+                }
               }
             ]
           }


### PR DESCRIPTION
## Context

As an Engineer I want to receive relevant updates about integration tests.

## Changes proposed in this pull request

* integration tests failure notifications will only happen if they are scheduled, e.g. on main, not on some branch that is being tested
* scheduled integration test passing will result in a notification (this only happens 3 times a day) 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
- [ ] I have manually tested the streamlit app
