### PR TITLE
Feature/redbox 146 split core api

### DIFF
--- a/core_api/Dockerfile
+++ b/core_api/Dockerfile
@@ -25,7 +25,7 @@ ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"
 COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
-ADD core_api/src/app.py /app/app.py
+COPY core_api/src/*.py /app/
 ADD download_embedder.py /app/
 ADD redbox/ /app/redbox
 

--- a/core_api/Dockerfile
+++ b/core_api/Dockerfile
@@ -25,7 +25,7 @@ ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"
 COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
-COPY core_api/src/*.py /app/
+COPY core_api/ /app/core_api/
 ADD download_embedder.py /app/
 ADD redbox/ /app/redbox
 
@@ -34,4 +34,4 @@ RUN type=cache python download_embedder.py --model_name ${EMBEDDING_MODEL}
 
 # Run FastAPI
 EXPOSE 5002
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "5002"]
+CMD ["uvicorn", "core_api.src.app:app", "--host", "0.0.0.0", "--port", "5002"]

--- a/core_api/src/app.py
+++ b/core_api/src/app.py
@@ -1,17 +1,11 @@
 import logging
 from datetime import datetime
-<<<<<<< HEAD
-from uuid import UUID
-=======
->>>>>>> 33ebdf6 (create file sub app)
 
 from fastapi import FastAPI
 from fastapi.responses import RedirectResponse
 from faststream.redis.fastapi import RedisRouter
 
-# from sub_apps.file import file_app
-from file import FileSubApp
-
+from core_api.src.routes.file import FileSubApp
 from redbox.model_db import SentenceTransformerDB
 from redbox.models import EmbeddingResponse, ModelInfo, Settings, StatusResponse
 from redbox.storage import ElasticsearchStorageHandler

--- a/core_api/src/file.py
+++ b/core_api/src/file.py
@@ -1,0 +1,118 @@
+# import logging
+from uuid import UUID
+
+from fastapi import FastAPI, HTTPException
+from pydantic import AnyHttpUrl
+
+from redbox.models import Chunk, File, FileStatus
+
+
+class FileSubApp:
+    def __init__(self, router, storage_handler, log, publisher, s3, env):
+        self.app = FastAPI()
+        self.router = router
+        self.storage_handler = storage_handler
+        self.log = log
+        self.publisher = publisher
+        self.s3 = s3
+        self.env = env
+
+        self.app.include_router(self.router)
+        self.router.add_api_route(
+            "/file", self.create_upload_file, methods=["POST"], tags=["file"]
+        )
+        self.router.add_api_route(
+            "/file/{file_uuid}",
+            self.get_file,
+            methods=["GET"],
+            response_model=File,
+            tags=["file"],
+        )
+        self.router.add_api_route(
+            "/{file_uuid}",
+            self.delete_file,
+            methods=["DELETE"],
+            response_model=File,
+            tags=["file"],
+        )
+        self.router.add_api_route(
+            "/file/{file_uuid}/chunks", self.get_file_chunks, tags=["file"]
+        )
+        self.router.add_api_route(
+            "/file/{file_uuid}/status", self.get_file_status, tags=["file"]
+        )
+
+    async def create_upload_file(
+        self, name: str, type: str, location: AnyHttpUrl
+    ) -> UUID:
+        """Upload a file to the object store and create a record in the database
+
+        Args:
+            name (str): The file name to be recorded
+            type (str): The file type to be recorded
+            location (AnyHttpUrl): The presigned file resource location
+
+        Returns:
+            UUID: The file uuid from the elastic database
+        """
+
+        file = File(
+            name=name,
+            url=str(location),  # avoids JSON serialisation error
+            content_type=type,
+        )
+
+        self.storage_handler.write_item(file)
+
+        self.log.info(f"publishing {file.uuid}")
+        await self.publisher.publish(file)
+
+        return file.uuid
+
+    def get_file(self, file_uuid: UUID) -> File:
+        """Get a file from the object store
+
+        Args:
+            file_uuid (str): The UUID of the file to get
+
+        Returns:
+            File: The file
+        """
+        return self.storage_handler.read_item(file_uuid, model_type="File")
+
+    def delete_file(self, file_uuid: UUID) -> File:
+        """Delete a file from the object store and the database
+
+        Args:
+            file_uuid (str): The UUID of the file to delete
+
+        Returns:
+            File: The file that was deleted
+        """
+        file = self.storage_handler.read_item(file_uuid, model_type="File")
+        self.s3.delete_object(Bucket=self.env.bucket_name, Key=file.name)
+        self.storage_handler.delete_item(file)
+
+        chunks = self.storage_handler.get_file_chunks(file.uuid)
+        self.storage_handler.delete_items(chunks)
+        return file
+
+    def get_file_chunks(self, file_uuid: UUID) -> list[Chunk]:
+        self.log.info(f"getting chunks for file {file_uuid}")
+        return self.storage_handler.get_file_chunks(file_uuid)
+
+    def get_file_status(self, file_uuid: UUID) -> FileStatus:
+        """Get the status of a file
+
+        Args:
+            file_uuid (str): The UUID of the file to get the status of
+
+        Returns:
+            File: The file with the updated status
+        """
+        try:
+            status = self.storage_handler.get_file_status(file_uuid)
+        except ValueError:
+            raise HTTPException(status_code=404, detail=f"File {file_uuid} not found")
+
+        return status

--- a/core_api/src/routes/file.py
+++ b/core_api/src/routes/file.py
@@ -1,23 +1,23 @@
-# import logging
 from uuid import UUID
 
-from fastapi import FastAPI, HTTPException
+from fastapi import HTTPException
 from pydantic import AnyHttpUrl
 
+from core_api.src.routes.sub_app import SubApp
 from redbox.models import Chunk, File, FileStatus
 
 
-class FileSubApp:
+class FileSubApp(SubApp):
     def __init__(self, router, storage_handler, log, publisher, s3, env):
-        self.app = FastAPI()
-        self.router = router
+        super().__init__(router)
+
+        # TODO: move some of these to the superclass if used more frequently
         self.storage_handler = storage_handler
         self.log = log
         self.publisher = publisher
         self.s3 = s3
         self.env = env
 
-        self.app.include_router(self.router)
         self.router.add_api_route(
             "/file", self.create_upload_file, methods=["POST"], tags=["file"]
         )
@@ -29,7 +29,7 @@ class FileSubApp:
             tags=["file"],
         )
         self.router.add_api_route(
-            "/{file_uuid}",
+            "/file/{file_uuid}",
             self.delete_file,
             methods=["DELETE"],
             response_model=File,

--- a/core_api/src/routes/sub_app.py
+++ b/core_api/src/routes/sub_app.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+
+
+class SubApp:
+    def __init__(self, router):
+        self.app = FastAPI()
+        self.router = router
+
+        self.app.include_router(self.router)


### PR DESCRIPTION
## Context
The core-api app was getting quite large. This change starts splitting out the api into sub apps. 

## Changes proposed in this pull request
I've created a class for a SubApp that can be added to the main app in `app.py`. There's a FileSubApp subclass that now contains the file endpoints, and will shortly start work on a ChatSubApp (in a later PR)

## Guidance to review
Run the core-api as usual (in docker or not) and check whether you can see the endpoints listed in `/docs`. 

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-146

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests
- [ ] I have manually tested the streamlit app
