### PR TITLE
Added an initial pass at a developer setup guide

### DIFF
--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -10,9 +10,9 @@ python == 3.11
 
 ## Installing packages
 
-Currently we use [poetry](https://python-poetry.org/) to manage our python packages. The list of poetry groups and python packages we install can be found [here](https://github.com/i-dot-ai/redbox-copilot/blob/main/pyproject.toml) in `pyproject.toml`.
+Currently, we use [poetry](https://python-poetry.org/) to manage our python packages. The list of poetry groups and python packages we install can be found [here](https://github.com/i-dot-ai/redbox-copilot/blob/main/pyproject.toml) in `pyproject.toml`.
 
-To install the packages, you'll first need to create a new virtual environment for python, and then run the following in that virtual environment.
+Run the following to install the packages into a virtual environment poetry will create.
 
 ``` bash
 poetry install
@@ -28,16 +28,15 @@ To run the project, create a new file called `.env` and populate this file with 
 
 ## Building and running the project
 
-To view all of the build commands, check the `Makefile` that can be found [here](https://github.com/i-dot-ai/redbox-copilot/blob/main/Makefile).
+To view all the build commands, check the `Makefile` that can be found [here](https://github.com/i-dot-ai/redbox-copilot/blob/main/Makefile).
 
-The project currently consists of multiple docker images needed to run the project in it's entirety. If you only need a subsection of the project running, for example if you're only editing the django app, you can run a subset of the images. The images currently in the project are:
+The project currently consists of multiple docker images needed to run the project in its entirety. If you only need a subsection of the project running, for example if you're only editing the django app, you can run a subset of the images. The images currently in the project are:
 
 - `elasticsearch`
 - `kibana`
 - `embedder`
 - `ingester`
 - `minio`
-- `miniocreatebuckets`
 - `redis`
 - `core-api`
 - `db`

--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -5,7 +5,7 @@
 To run this project, you'll need `python`, `pip` and `poetry` installed.
 
 ```
-python = <=3.11, <3.12
+python == 3.11
 ```
 
 ## Installing packages

--- a/DEVELOPER_SETUP.md
+++ b/DEVELOPER_SETUP.md
@@ -1,0 +1,110 @@
+# Developer setup guide
+
+## Requirements
+
+To run this project, you'll need `python`, `pip` and `poetry` installed.
+
+```
+python = <=3.11, <3.12
+```
+
+## Installing packages
+
+Currently we use [poetry](https://python-poetry.org/) to manage our python packages. The list of poetry groups and python packages we install can be found [here](https://github.com/i-dot-ai/redbox-copilot/blob/main/pyproject.toml) in `pyproject.toml`.
+
+To install the packages, you'll first need to create a new virtual environment for python, and then run the following in that virtual environment.
+
+``` bash
+poetry install
+```
+
+## Setting environment variables
+
+We use `.env` files to populate the environment variables for local development. When cloning the repository the files `.env.test`, `.env.django`, `.env.integration` and `.env.example` will be populated.
+
+To run the project, create a new file called `.env` and populate this file with the setting names from `.env.example` and the values these settings need.
+
+**`.env` is in `.gitignore` and should not be committed to git**
+
+## Building and running the project
+
+To view all of the build commands, check the `Makefile` that can be found [here](https://github.com/i-dot-ai/redbox-copilot/blob/main/Makefile).
+
+The project currently consists of multiple docker images needed to run the project in it's entirety. If you only need a subsection of the project running, for example if you're only editing the django app, you can run a subset of the images. The images currently in the project are:
+
+- `elasticsearch`
+- `kibana`
+- `embedder`
+- `ingester`
+- `minio`
+- `miniocreatebuckets`
+- `redis`
+- `core-api`
+- `db`
+- `django-app`
+
+To build the images needed to run the project, use this command:
+
+``` bash
+make build
+```
+
+or 
+
+``` bash
+docker compose build
+```
+
+Once those images have built, you can run them using:
+
+``` bash
+make run
+```
+
+or 
+
+``` bash
+docker compose up
+```
+
+Some parts of the project can be run independently for development, for example the django application, which can be run with:
+
+``` bash
+docker compose up django-app
+```
+
+For any other commands available, check the `Makefile` [here](https://github.com/i-dot-ai/redbox-copilot/blob/main/Makefile).
+
+## How to run tests
+
+Tests are split into different commands based on the application the tests are for. For each application there is a separate `make` command to run those tests, these are:
+
+For the django app:
+
+``` bash
+make test-django
+```
+
+For the core API:
+
+``` bash
+make test-core-api
+```
+
+For the embedder:
+
+``` bash
+make test-embedder
+```
+
+For the ingester:
+
+``` bash
+make test-ingester
+```
+
+For integration tests:
+
+``` bash
+make test-integration
+```

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ reqs:
 	poetry install
 
 run:
-	docker compose up -d elasticsearch kibana embedder ingester minio miniocreatebuckets redis core-api db django-app
+	docker compose up -d elasticsearch kibana embedder ingester minio redis core-api db django-app
 
 stop:
 	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,14 +121,6 @@ services:
       - redbox-app-network
     volumes:
       - ./data/objectstore:/data
-  miniocreatebuckets:
-    image: minio/mc
-    depends_on:
-      - minio
-    networks:
-      - redbox-app-network
-    entrypoint: >
-      /bin/sh -c " /usr/bin/mc alias set redbox http://minio:9000 minioadmin minioadmin; /usr/bin/mc mb redbox/redbox-storage-dev; /usr/bin/mc policy set public redbox/redbox-storage-dev; exit 0; "
   elasticsearch:
     image: elasticsearch:8.12.0
     volumes:


### PR DESCRIPTION
## Context

We need a developer setup guide to help new joiners get set up with the project and learn how to run it locally.

## Changes proposed in this pull request

Added a developer guide with the following sections:

- Requirements
- Installing packages
- Setting environment variables
- Building and running the project
- How to run tests

## Guidance to review

Run `make docs-serve`
