### PR TITLE
bugfix/gh-workflow-syntax-fix

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -66,7 +66,7 @@ jobs:
         python -m pytest tests
 
     - name: notify slack failure
-      id: slack failure
+      id: slack-failure
       uses: slackapi/slack-github-action@v1.24.0
       if: ${{ failure() && github.event_name == 'schedule' }}
       with:
@@ -105,7 +105,7 @@ jobs:
         SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
     - name: notify slack pass
-      id: slack pass
+      id: slack-pass
       uses: slackapi/slack-github-action@v1.24.0
       if: ${{ success() && github.event_name == 'schedule' }}
       with:


### PR DESCRIPTION
## Context

I want to fix:
```
[Invalid workflow file: .github/workflows/integration.yml#L69](https://github.com/i-dot-ai/redbox-copilot/actions/runs/8646345564/workflow)
The workflow is not valid. .github/workflows/integration.yml (Line: 69, Col: 11): The identifier 'slack failure' is invalid. IDs may only contain alphanumeric characters, '_', and '-'. IDs must start with a letter or '_' and and must be less than 100 characters
```

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
- [ ] I have manually tested the streamlit app
