### PR TITLE
bugfix/implicit single connection

### DIFF
--- a/core_api/src/publisher_handler.py
+++ b/core_api/src/publisher_handler.py
@@ -1,0 +1,23 @@
+from faststream.redis import RedisBroker
+
+from redbox.models import File
+
+
+class FilePublisher:
+    """This class is a bit of a hack to overcome a shortcoming (bug?) in faststream
+    whereby the broker is not automatically connected in sub-applications.
+
+    TODO: fix this properly, or raise an issue against faststream
+    """
+
+    def __init__(self, broker: RedisBroker, queue_name: str):
+        self.connected = False
+        self.broker = broker
+        self.queue_name = queue_name
+
+    async def publish(self, file: File):
+        if not self.connected:
+            # we only do this once
+            await self.broker.connect()
+            self.connected = True
+        return self.broker.publish(file, self.queue_name)

--- a/core_api/src/publisher_handler.py
+++ b/core_api/src/publisher_handler.py
@@ -20,4 +20,4 @@ class FilePublisher:
             # we only do this once
             await self.broker.connect()
             self.connected = True
-        return self.broker.publish(file, self.queue_name)
+        await self.broker.publish(file, self.queue_name)

--- a/core_api/src/routes/file.py
+++ b/core_api/src/routes/file.py
@@ -3,7 +3,6 @@ from uuid import UUID
 
 from fastapi import FastAPI, HTTPException
 from faststream.redis.fastapi import RedisRouter
-from pydantic import AnyHttpUrl
 
 from core_api.src.publisher_handler import FilePublisher
 from redbox.models import Chunk, File, FileStatus, Settings
@@ -49,30 +48,22 @@ file_app.include_router(router)
 
 
 @file_app.post("/", tags=["file"])
-async def create_upload_file(name: str, type: str, location: AnyHttpUrl) -> UUID:
-    """Upload a file to the object store and create a record in the database
+async def add_file(file: File) -> File:
+    """Create a File record in the database
 
     Args:
-        name (str): The file name to be recorded
-        type (str): The file type to be recorded
-        location (AnyHttpUrl): The presigned file resource location
+        file (File): The file to be recorded
 
     Returns:
-        UUID: The file uuid from the elastic database
+        File: The file uuid from the elastic database
     """
-
-    file = File(
-        name=name,
-        url=str(location),  # avoids JSON serialisation error
-        content_type=type,
-    )
 
     storage_handler.write_item(file)
 
     log.info(f"publishing {file.uuid}")
     await file_publisher.publish(file)
 
-    return file.uuid
+    return file
 
 
 @file_app.get("/{file_uuid}", response_model=File, tags=["file"])
@@ -99,7 +90,7 @@ def delete_file(file_uuid: UUID) -> File:
         File: The file that was deleted
     """
     file = storage_handler.read_item(file_uuid, model_type="File")
-    s3.delete_object(Bucket=env.bucket_name, Key=file.name)
+    s3.delete_object(Bucket=env.bucket_name, Key=file.key)
     storage_handler.delete_item(file)
 
     chunks = storage_handler.get_file_chunks(file.uuid)

--- a/core_api/tests/conftest.py
+++ b/core_api/tests/conftest.py
@@ -48,11 +48,6 @@ def elasticsearch_storage_handler(es_client):
 
 @pytest.fixture
 def file(s3_client, file_pdf_path) -> YieldFixture[File]:
-    """
-    TODO: this is a cut and paste of core_api:create_upload_file
-    When we come to test core_api we should think about
-    the relationship between core_api and the ingester app
-    """
     file_name = os.path.basename(file_pdf_path)
     file_type = f'.{file_name.split(".")[-1]}'
 
@@ -64,15 +59,7 @@ def file(s3_client, file_pdf_path) -> YieldFixture[File]:
             Tagging=f"file_type={file_type}",
         )
 
-    authenticated_s3_url = s3_client.generate_presigned_url(
-        "get_object",
-        Params={"Bucket": env.bucket_name, "Key": file_name},
-        ExpiresIn=3600,
-    )
-
-    # Strip off the query string (we don't need the keys)
-    simple_s3_url = authenticated_s3_url.split("?")[0]
-    file_record = File(name=file_name, url=simple_s3_url, content_type=file_type)
+    file_record = File(key=file_name, bucket=env.bucket_name)
 
     yield file_record
 

--- a/django_app/redbox_app/redbox_core/client.py
+++ b/django_app/redbox_app/redbox_core/client.py
@@ -47,20 +47,16 @@ class CoreApiClient:
     def upload_file(self, s3_url: str, name: str, extension: str):
         if self.host == "testserver":
             file = {
-                "url": "s3 url",
-                "content_type": "application/pdf",
-                "name": "my-test-file.pdf",
-                "text": "once upon a time....",
-                "processing_status": "uploaded",
+                "key": "my-test-file.pdf",
+                "bucket": settings.BUCKET_NAME,
             }
             return file
 
         response = requests.post(
             f"{self.url}/file",
-            params={
-                "name": name,
-                "type": extension,
-                "location": s3_url,
+            json={
+                "key": name,
+                "bucket": settings.BUCKET_NAME,
             },
         )
         if response.status_code != 201:

--- a/django_app/redbox_app/redbox_core/client.py
+++ b/django_app/redbox_app/redbox_core/client.py
@@ -44,10 +44,10 @@ class CoreApiClient:
     def url(self) -> str:
         return f"{self.host}:{self.port}"
 
-    def upload_file(self, s3_url: str, name: str, extension: str):
+    def upload_file(self, name: str):
         if self.host == "testserver":
             file = {
-                "key": "my-test-file.pdf",
+                "key": name,
                 "bucket": settings.BUCKET_NAME,
             }
             return file

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -74,7 +74,7 @@ def documents_view(request):
 def get_file_extension(file):
     # TODO: use a third party checking service to validate this
 
-    _, extension = os.path.splitext(file.name)
+    _, extension = os.path.splitext(file.key)
     return extension
 
 
@@ -88,7 +88,7 @@ def upload_view(request):
 
         file_extension = get_file_extension(uploaded_file)
 
-        if uploaded_file.name is None:
+        if uploaded_file.key is None:
             errors["upload_doc"].append("File has no name")
         if uploaded_file.content_type is None:
             errors["upload_doc"].append("File has no content-type")
@@ -105,7 +105,7 @@ def upload_view(request):
                 Bucket=settings.BUCKET_NAME,
                 Fileobj=uploaded_file,
                 Key=file_key,
-                ExtraArgs={"Tagging": f"file_type={uploaded_file.content_type}"},
+                ExtraArgs={"Tagging": f"file_type={file_extension}"},
                 Config=TransferConfig(
                     multipart_chunksize=CHUNK_SIZE,
                     preferred_transfer_client="auto",
@@ -132,7 +132,7 @@ def upload_view(request):
 
             try:
                 api.upload_file(
-                    uploaded_file.name,
+                    uploaded_file.key,
                     file_extension,
                     simple_s3_url,
                 )

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -74,7 +74,7 @@ def documents_view(request):
 def get_file_extension(file):
     # TODO: use a third party checking service to validate this
 
-    _, extension = os.path.splitext(file.key)
+    _, extension = os.path.splitext(file.name)
     return extension
 
 
@@ -88,7 +88,7 @@ def upload_view(request):
 
         file_extension = get_file_extension(uploaded_file)
 
-        if uploaded_file.key is None:
+        if uploaded_file.name is None:
             errors["upload_doc"].append("File has no name")
         if uploaded_file.content_type is None:
             errors["upload_doc"].append("File has no content-type")
@@ -105,7 +105,7 @@ def upload_view(request):
                 Bucket=settings.BUCKET_NAME,
                 Fileobj=uploaded_file,
                 Key=file_key,
-                ExtraArgs={"Tagging": f"file_type={file_extension}"},
+                ExtraArgs={"Tagging": f"file_type={uploaded_file.content_type}"},
                 Config=TransferConfig(
                     multipart_chunksize=CHUNK_SIZE,
                     preferred_transfer_client="auto",
@@ -115,27 +115,11 @@ def upload_view(request):
                 ),
             )
 
-            # TODO: Handle S3 upload errors
-            authenticated_s3_url = s3.generate_presigned_url(
-                "get_object",
-                Params={
-                    "Bucket": settings.BUCKET_NAME,
-                    "Key": file_key,
-                },
-                ExpiresIn=3600,
-            )
-            # Strip off the query string (we don't need the keys)
-            simple_s3_url = authenticated_s3_url.split("?")[0]
-
             # ingest file
             api = CoreApiClient(host=settings.CORE_API_HOST, port=settings.CORE_API_PORT)
 
             try:
-                api.upload_file(
-                    uploaded_file.key,
-                    file_extension,
-                    simple_s3_url,
-                )
+                api.upload_file(uploaded_file.name)
                 # TODO: update improved File object with elastic uuid
                 uploaded = True
             except ValueError as value_error:

--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -152,7 +152,7 @@ CSP_DEFAULT_SRC = (
     "s3.amazonaws.com",
 )
 CSP_SCRIPT_SRC = (
-    "'self'", 
+    "'self'",
     "plausible.io",
     "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",
 )

--- a/ingester/tests/conftest.py
+++ b/ingester/tests/conftest.py
@@ -60,18 +60,9 @@ def file(s3_client, file_pdf_path):
             Tagging=f"file_type={file_type}",
         )
 
-    authenticated_s3_url = s3_client.generate_presigned_url(
-        "get_object",
-        Params={"Bucket": env.bucket_name, "Key": file_name},
-        ExpiresIn=3600,
-    )
-
-    # Strip off the query string (we don't need the keys)
-    simple_s3_url = authenticated_s3_url.split("?")[0]
     file_record = File(
-        name=file_name,
-        url=simple_s3_url,
-        content_type=file_type,
+        key=file_name,
+        bucket=env.bucket_name,
     )
 
     yield file_record

--- a/redbox/models/file.py
+++ b/redbox/models/file.py
@@ -18,53 +18,11 @@ class ProcessingStatusEnum(str, Enum):
     complete = "complete"
 
 
-class ContentType(str, Enum):
-    EML = ".eml"
-    HTML = ".html"
-    HTM = ".htm"
-    JSON = ".json"
-    MD = ".md"
-    MSG = ".msg"
-    RST = ".rst"
-    RTF = ".rtf"
-    TXT = ".txt"
-    XML = ".xml"
-    JPEG = ".jpeg"  # Must have tesseract installed
-    PNG = ".png"  # Must have tesseract installed
-    CSV = ".csv"
-    DOC = ".doc"
-    DOCX = ".docx"
-    EPUB = ".epub"
-    ODT = ".odt"
-    PDF = ".pdf"
-    PPT = ".ppt"
-    PPTX = ".pptx"
-    TSV = ".tsv"
-    XLSX = ".xlsx"
-
-
 class File(PersistableModel):
-    url: AnyUrl = Field(description="s3 url")
-    content_type: ContentType = Field(description="content_type of file")
-    name: str = Field(description="file name")
-    text: Optional[str] = Field(description="file content", default=None)
+    """Reference to file stored on s3"""
 
-    @computed_field
-    def text_hash(self) -> str:
-        return hashlib.md5(
-            (self.text or "").encode(encoding="UTF-8", errors="strict"),
-            usedforsecurity=False,
-        ).hexdigest()
-
-    @computed_field
-    def token_count(self) -> int:
-        return len(encoding.encode(self.text or ""))
-
-    def to_document(self) -> Document:
-        return Document(
-            page_content=f"<Doc{self.uuid}>Title: {self.name}\n\n{self.text}</Doc{self.uuid}>\n\n",
-            metadata={"source": self.url},
-        )
+    key: str = Field(description="file key")
+    bucket: str = Field(description="s3 bucket")
 
 
 class Chunk(PersistableModel):

--- a/redbox/parsing/chunkers.py
+++ b/redbox/parsing/chunkers.py
@@ -10,7 +10,7 @@ s3_client = env.s3_client()
 def other_chunker(file: File) -> list[Chunk]:
     authenticated_s3_url = s3_client.generate_presigned_url(
         "get_object",
-        Params={"Bucket": env.bucket_name, "Key": file.name},
+        Params={"Bucket": env.bucket_name, "Key": file.key},
         ExpiresIn=3600,
     )
 

--- a/redbox/parsing/file_chunker.py
+++ b/redbox/parsing/file_chunker.py
@@ -1,8 +1,35 @@
+from enum import Enum
+
 from sentence_transformers import SentenceTransformer
 
-from redbox.models.file import Chunk, ContentType, File
+from redbox.models.file import Chunk, File
 from redbox.parsing.chunk_clustering import cluster_chunks
 from redbox.parsing.chunkers import other_chunker
+
+
+class ContentType(str, Enum):
+    EML = ".eml"
+    HTML = ".html"
+    HTM = ".htm"
+    JSON = ".json"
+    MD = ".md"
+    MSG = ".msg"
+    RST = ".rst"
+    RTF = ".rtf"
+    TXT = ".txt"
+    XML = ".xml"
+    JPEG = ".jpeg"  # Must have tesseract installed
+    PNG = ".png"  # Must have tesseract installed
+    CSV = ".csv"
+    DOC = ".doc"
+    DOCX = ".docx"
+    EPUB = ".epub"
+    ODT = ".odt"
+    PDF = ".pdf"
+    PPT = ".ppt"
+    PPTX = ".pptx"
+    TSV = ".tsv"
+    XLSX = ".xlsx"
 
 
 class FileChunker:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -23,18 +23,11 @@ def test_upload_to_elastic(file_pdf_path, s3_client):
             ExtraArgs={"Tagging": "file_type=pdf"},
         )
 
-        authenticated_s3_url = s3_client.generate_presigned_url(
-            "get_object",
-            Params={"Bucket": bucket_name, "Key": file_key},
-            ExpiresIn=3600,
-        )
-
         response = requests.post(
             url="http://localhost:5002/file",
             params={
-                "name": "filename",
-                "type": ".pdf",
-                "location": authenticated_s3_url,
+                "name": file_key,
+                "bucket": bucket_name,
             },
         )
         assert response.status_code == 200

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -26,7 +26,7 @@ def test_upload_to_elastic(file_pdf_path, s3_client):
         response = requests.post(
             url="http://localhost:5002/file",
             json={
-                "name": file_key,
+                "key": file_key,
                 "bucket": bucket_name,
             },
         )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -31,7 +31,7 @@ def test_upload_to_elastic(file_pdf_path, s3_client):
             },
         )
         assert response.status_code == 200
-        file_uuid = response.json()
+        file_uuid = response.json()["uuid"]
 
         timeout = 120
         start_time = time.time()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -25,7 +25,7 @@ def test_upload_to_elastic(file_pdf_path, s3_client):
 
         response = requests.post(
             url="http://localhost:5002/file",
-            params={
+            json={
                 "name": file_key,
                 "bucket": bucket_name,
             },


### PR DESCRIPTION
## Context

The fast stream redis broker does not operate to automatically connect within a sub application. to get round this we have been establishing the connection each time a file is posted. In this PR we ensure this happens only once.

## Changes proposed in this pull request

As I could not find thus issue addressed in the fast stream documentation I have created a class to manage the brokers lifecycle so that the connection is only made once 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-154

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/8673397377
- [ ] I have manually tested the streamlit app
