### PR TITLE
Fix browser console errors

### DIFF
--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -150,7 +150,11 @@ LOGIN_REDIRECT_URL = "homepage"
 CSP_DEFAULT_SRC = (
     "'self'",
     "s3.amazonaws.com",
+)
+CSP_SCRIPT_SRC = (
+    "'self'", 
     "plausible.io",
+    "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",
 )
 CSP_OBJECT_SRC = ("'none'",)
 CSP_REQUIRE_TRUSTED_TYPES_FOR = ("'script'",)

--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -7,11 +7,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="#0b0c0c">
 
-  <link rel="icon" sizes="48x48" href="{{static(" govuk-assets/images/favicon.ico")}}">
-  <link rel="icon" sizes="any" href="{{static(" govuk-assets/images/favicon.svg")}}" type="image/svg+xml">
-  <link rel="mask-icon" href="{{static(" govuk-assets/images/govuk-icon-mask.svg")}}" color="#0b0c0c">
-  <link rel="apple-touch-icon" href="{{static(" govuk-assets/images/govuk-icon-180.png")}}">
-  <link rel="manifest" href="{{static(" govuk-assets/manifest.json")}}">
+  <link rel="icon" sizes="48x48" href="{{static("govuk-assets/images/favicon.ico")}}">
+  <link rel="icon" sizes="any" href="{{static("govuk-assets/images/favicon.svg")}}" type="image/svg+xml">
+  <link rel="mask-icon" href="{{static("govuk-assets/images/govuk-icon-mask.svg")}}" color="#0b0c0c">
+  <link rel="apple-touch-icon" href="{{static("govuk-assets/images/govuk-icon-180.png")}}">
+  <link rel="manifest" href="{{static("govuk-assets/manifest.json")}}">
 
   <meta name="robots" content="noindex, nofollow">
   {% compress css %}
@@ -21,7 +21,7 @@
 </head>
 
 <body class="govuk-template__body">
-  <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+  <script hash="sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=">document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
 
   <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 

--- a/django_app/static/govuk-frontend/assets/manifest.json
+++ b/django_app/static/govuk-frontend/assets/manifest.json
@@ -1,0 +1,40 @@
+{
+    "icons": [
+      {
+        "src": "images/favicon.ico",
+        "type": "image/x-icon",
+        "sizes": "48x48"
+      },
+      {
+        "src": "images/favicon.svg",
+        "type": "image/svg+xml",
+        "sizes": "150x150",
+        "purpose": "any"
+      },
+      {
+        "src": "images/govuk-icon-180.png",
+        "type": "image/png",
+        "sizes": "180x180",
+        "purpose": "maskable"
+      },
+      {
+        "src": "images/govuk-icon-192.png",
+        "type": "image/png",
+        "sizes": "192x192",
+        "purpose": "maskable"
+      },
+      {
+        "src": "images/govuk-icon-512.png",
+        "type": "image/png",
+        "sizes": "512x512",
+        "purpose": "maskable"
+      },
+      {
+        "src": "images/govuk-icon-mask.svg",
+        "type": "image/svg+xml",
+        "sizes": "150x150",
+        "purpose": "monochrome"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
## Context

While working on something else, I noticed a couple of browser console errors:

* The gov.uk inline script is being blocked by our Content Security Policy (meaning no gov.uk javascript is running)
* Missing manifest.json file

This update addresses both of these issues.


## Changes proposed in this pull request

* Update the CSP to allow the inline script (but only this inline script) by using a hash
* Add the manifest.json file to the project. This alone didn't fully fix the problem, but removing the whitespace from the URL did


## Guidance to review

* Visit any page and check there are no browser console errors
* Please look at the CSP changes in `settings.py` to confirm they are sensible

