### PR TITLE
Feature/redbox 106 add vanilla chat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ rebuild:
 	docker compose build --no-cache
 
 test-core-api:
-	poetry install --no-root --no-ansi --with worker,api,dev --without ai,ingester
+	poetry install --no-root --no-ansi --with worker,api,dev,ai --without ingester
 	poetry run pytest core_api/tests --cov=core_api/src -v --cov-report=term-missing --cov-fail-under=45
 
 test-embedder:

--- a/core_api/Dockerfile
+++ b/core_api/Dockerfile
@@ -14,7 +14,7 @@ ADD pyproject.toml poetry.lock /app/
 ADD download_embedder.py /app/
 ADD redbox/ /app/redbox
 
-RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install --no-root --no-ansi --with api --without ai,ingester,dev,worker
+RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install --no-root --no-ansi --with api,ai --without ingester,dev,worker
 
 FROM python:3.11-slim-buster as runtime
 ARG EMBEDDING_MODEL

--- a/core_api/src/app.py
+++ b/core_api/src/app.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from fastapi import FastAPI
 from fastapi.responses import RedirectResponse
 
+from core_api.src.routes.chat import chat_app
 from core_api.src.routes.file import file_app
 from redbox.model_db import SentenceTransformerDB
 from redbox.models import EmbeddingResponse, ModelInfo, Settings, StatusResponse
@@ -88,4 +89,5 @@ def embed_sentences(sentences: list[str]) -> EmbeddingResponse:
     return model_db.embed_sentences(sentences)
 
 
+app.mount("/chat", chat_app)
 app.mount("/file", file_app)

--- a/core_api/src/routes/chat.py
+++ b/core_api/src/routes/chat.py
@@ -57,23 +57,24 @@ def simple_chat(chat_history: List[ChatMessage]) -> StreamingResponse:
 
     if len(chat_history) < 2:
         raise HTTPException(
-            status_code=421,
+            status_code=422,
             detail="Chat history should include both system and user prompts",
         )
 
-    if chat_history[-1]["role"] != "system":
+    if chat_history[0]["role"] != "system":
         raise HTTPException(
-            status_code=421,
+            status_code=422,
             detail="The first entry in the chat history should be a system prompt",
         )
 
     if chat_history[-1]["role"] != "user":
         raise HTTPException(
-            status_code=421,
+            status_code=422,
             detail="The final entry in the chat history should be a user question",
         )
 
     # TODO: handle errors from LLM request
+    # maybe litellm.exceptions.APIError: OpenAIException?
 
     question = chat_history[-1]
     previous_history = chat_history[0:-1]

--- a/core_api/src/routes/chat.py
+++ b/core_api/src/routes/chat.py
@@ -1,0 +1,87 @@
+from typing import List, Literal
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
+from langchain.chains.llm import LLMChain
+from langchain_community.chat_models import ChatLiteLLM
+from langchain_core.prompts import ChatPromptTemplate
+from typing_extensions import TypedDict
+
+from redbox.models import Settings
+
+env = Settings()
+
+
+chat_app = FastAPI(
+    title="Core Chat API",
+    description="Redbox Core Chat API",
+    version="0.1.0",
+    openapi_tags=[
+        {"name": "chat", "description": "Chat endpoints"},
+    ],
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
+)
+
+
+llm = ChatLiteLLM(
+    model="gpt-3.5-turbo",  # TODO: set with env var
+    # TODO: set max_tokens and temperature
+    streaming=True,
+)
+
+
+# TODO: decide what we're doing with our backend ChatMessage class
+class ChatMessage(TypedDict):
+    text: str
+    role: Literal["user", "ai", "system"]
+
+
+@chat_app.post("/vanilla", tags=["chat"])
+def simple_chat(chat_history: List[ChatMessage]) -> StreamingResponse:
+    """Get a LLM response to a question history
+
+    Args:
+        chat_history ([{
+            text (str): the prompt text
+            role (Literal["user", "ai", "system"])
+        }]): a List containing the full chat history
+
+    The first chat_history object should be the "system" prompt.
+    The final chat_history object should be the "user" question.
+
+    Returns:
+        StreamingResponse: a stream of the chain response
+    """
+
+    if len(chat_history) < 2:
+        raise HTTPException(
+            status_code=421,
+            detail="Chat history should include both system and user prompts",
+        )
+
+    if chat_history[-1]["role"] != "system":
+        raise HTTPException(
+            status_code=421,
+            detail="The first entry in the chat history should be a system prompt",
+        )
+
+    if chat_history[-1]["role"] != "user":
+        raise HTTPException(
+            status_code=421,
+            detail="The final entry in the chat history should be a user question",
+        )
+
+    # TODO: handle errors from LLM request
+
+    question = chat_history[-1]
+    previous_history = chat_history[0:-1]
+
+    chat_prompt = ChatPromptTemplate.from_messages(
+        (msg["role"], msg["text"]) for msg in previous_history
+    )
+
+    chain = LLMChain(llm=llm, prompt=chat_prompt)
+
+    return chain.stream({"input": question["text"]})

--- a/core_api/src/routes/chat.py
+++ b/core_api/src/routes/chat.py
@@ -79,9 +79,7 @@ def simple_chat(chat_history: List[ChatMessage]) -> StreamingResponse:
     question = chat_history[-1]
     previous_history = chat_history[0:-1]
 
-    chat_prompt = ChatPromptTemplate.from_messages(
-        (msg["role"], msg["text"]) for msg in previous_history
-    )
+    chat_prompt = ChatPromptTemplate.from_messages((msg["role"], msg["text"]) for msg in previous_history)
 
     chain = LLMChain(llm=llm, prompt=chat_prompt)
 

--- a/core_api/tests/routes/test_chat.py
+++ b/core_api/tests/routes/test_chat.py
@@ -34,9 +34,7 @@ def mock_get_chain(llm, prompt):
 
 @pytest.mark.parametrize("chat_history, status_code", test_history)
 def test_simple_chat(chat_history, status_code, app_client, monkeypatch):
-    monkeypatch.setattr(
-        "langchain_core.prompts.ChatPromptTemplate.from_messages", mock_chat_prompt
-    )
+    monkeypatch.setattr("langchain_core.prompts.ChatPromptTemplate.from_messages", mock_chat_prompt)
     monkeypatch.setattr("core_api.src.routes.chat.LLMChain", mock_get_chain)
 
     response = app_client.post("/chat/vanilla", json=chat_history)

--- a/core_api/tests/routes/test_chat.py
+++ b/core_api/tests/routes/test_chat.py
@@ -1,0 +1,43 @@
+import pytest
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.prompt_values import ChatPromptValue
+
+system_chat = {"text": "test", "role": "system"}
+user_chat = {"text": "test", "role": "user"}
+
+test_history = [
+    ([system_chat], 422),
+    ([user_chat, system_chat], 422),
+    ([system_chat, system_chat], 422),
+    ([system_chat, user_chat], 200),
+]
+
+
+def mock_chat_prompt(input):
+    return ChatPromptValue(
+        messages=[
+            SystemMessage(content="You are a helpful AI bot."),
+            HumanMessage(content="Hello, how are you doing?"),
+        ]
+    )
+
+
+class MockChain:
+    @staticmethod
+    def stream(input):
+        yield [{"input": "Test input", "text": "Test output"}]
+
+
+def mock_get_chain(llm, prompt):
+    return MockChain()
+
+
+@pytest.mark.parametrize("chat_history, status_code", test_history)
+def test_simple_chat(chat_history, status_code, app_client, monkeypatch):
+    monkeypatch.setattr(
+        "langchain_core.prompts.ChatPromptTemplate.from_messages", mock_chat_prompt
+    )
+    monkeypatch.setattr("core_api.src.routes.chat.LLMChain", mock_get_chain)
+
+    response = app_client.post("/chat/vanilla", json=chat_history)
+    assert response.status_code == status_code

--- a/redbox/llm/prompts/core.py
+++ b/redbox/llm/prompts/core.py
@@ -6,18 +6,6 @@ non-partisan. You are not a replacement for human judgement, but you can help hu
 make more informed decisions. If you are asked a question you cannot answer based on your following instructions, you should say so.\
 Be concise and professional in your responses. Respond in markdown format.
 
-=== CURRENT DATE ===
-
-The current date is {current_date}. Ensure to factor in the current date when providing responses \
-about time-related information in your inputs.
-
-=== USER INFO ===
-
-You are currently helping this user:
-{user_info}
-
-Ensure to tailor your responses to the user's needs and preferences.
-
 === RULES ===
 
 All responses to Tasks **MUST** be translated into the user's preferred language.\


### PR DESCRIPTION
## Context

As well as the RAG chat, we also want the option of a simple chat API that connects the user to ChatGPT (or Anthropic) without using document search.

## Changes proposed in this pull request

Adds a `/chat/vanilla` endpoint to query an LLM with a conversation history.

## Guidance to review
Some questions:
* Where do we inject the system prompt? In Django, or Core-api?
* What are we doing with the Chat model in the redbox-core? Do we need to update this?
* What information are we surfacing to users about LLM errors?
* Is there a better way to test the LLM integration than the monkeypatching here?

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-106 

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
