### PR TITLE
feature/use html as example file

### DIFF
--- a/ingester/Dockerfile
+++ b/ingester/Dockerfile
@@ -16,7 +16,8 @@ RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install --no-root --no-an
 FROM python:3.11-slim-buster as runtime
 RUN apt update && apt-get install -y \
     poppler-utils \
-    tesseract-ocr
+    tesseract-ocr \
+    libmagic-dev
 
 ARG EMBEDDING_MODEL
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,12 +6,12 @@ from botocore.exceptions import ClientError
 
 
 @pytest.fixture
-def file_pdf_path():
+def file_path():
     path = os.path.join(
         os.path.dirname(os.path.abspath(__file__)),
         "data",
-        "pdf",
-        "Cabinet Office - Wikipedia.pdf",
+        "html",
+        "example.html",
     )
     yield path
 

--- a/tests/data/html/example.html
+++ b/tests/data/html/example.html
@@ -1,0 +1,37 @@
+<HTML>
+
+<HEAD>
+
+<TITLE>Your Title Here</TITLE>
+
+</HEAD>
+
+<BODY BGCOLOR="FFFFFF">
+
+<CENTER><IMG SRC="clouds.jpg" ALIGN="BOTTOM"> </CENTER>
+
+<HR>
+
+<a href="http://somegreatsite.com">Link Name</a>
+
+is a link to another nifty site
+
+<H1>This is a Header</H1>
+
+<H2>This is a Medium Header</H2>
+
+Send me mail at <a href="mailto:support@yourcompany.com">
+
+support@yourcompany.com</a>.
+
+<P> This is a new paragraph!
+
+<P> <B>This is a new paragraph!</B>
+
+<BR> <B><I>This is a new sentence without a paragraph break, in bold italics.</I></B>
+
+<HR>
+
+</BODY>
+
+</HTML>

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -7,20 +7,21 @@ import requests
 # TODO: add e2e tests involving the Django app, checking S3 upload
 
 
-def test_upload_to_elastic(file_pdf_path, s3_client):
+def test_upload_to_elastic(file_path, s3_client):
     """
     When I POST file data to core-api/file
     I Expect a Chunk with a non-null embedding ... eventually
     """
 
-    with open(file_pdf_path, "rb") as f:
-        file_key = os.path.basename(file_pdf_path)
+    with open(file_path, "rb") as f:
+        file_key = os.path.basename(file_path)
+        file_type = os.path.splitext(file_key)[-1]
         bucket_name = "redbox-storage-dev"
         s3_client.upload_fileobj(
             Bucket=bucket_name,
             Fileobj=f,
             Key=file_key,
-            ExtraArgs={"Tagging": "file_type=pdf"},
+            ExtraArgs={"Tagging": f"file_type={file_type}"},
         )
 
         response = requests.post(


### PR DESCRIPTION
## Context

As an Engineer I want the integration tests to pass quickly.

## Changes proposed in this pull request

1. I have swapped the .pdf for an .html file which is easier to to parse.
2. I have added `libmagic` to the ingester's `Dockerfile` so that it can detect the file type

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/8708225612
