### PR TITLE
feature/rationalise-file-endpoint-post

### DIFF
--- a/core_api/src/routes/file.py
+++ b/core_api/src/routes/file.py
@@ -51,8 +51,7 @@ file_app.include_router(router)
 class FileRequest(BaseModel):
     """Reference to file stored on s3"""
 
-    key: str = Field(description="file key", examples=["sales.csv", "README.txt"])
-    bucket: str = Field(description="s3 bucket", examples=[env.bucket_name])
+    key: str = Field(description="file key", examples=["policies.pdf"])
 
 
 @file_app.post("/", tags=["file"])
@@ -66,7 +65,7 @@ async def add_file(file_request: FileRequest) -> File:
         File: The file uuid from the elastic database
     """
 
-    file = File(key=file_request.key, bucket=file_request.bucket)
+    file = File(key=file_request.key, bucket=env.bucket_name)
 
     storage_handler.write_item(file)
 

--- a/core_api/src/routes/file.py
+++ b/core_api/src/routes/file.py
@@ -51,8 +51,8 @@ file_app.include_router(router)
 class FileRequest(BaseModel):
     """Reference to file stored on s3"""
 
-    key: str = Field(description="file key")
-    bucket: str = Field(description="s3 bucket")
+    key: str = Field(description="file key", examples=["sales.csv", "README.txt"])
+    bucket: str = Field(description="s3 bucket", examples=[env.bucket_name])
 
 
 @file_app.post("/", tags=["file"])

--- a/django_app/redbox_app/redbox_core/client.py
+++ b/django_app/redbox_app/redbox_core/client.py
@@ -54,10 +54,7 @@ class CoreApiClient:
 
         response = requests.post(
             f"{self.url}/file",
-            json={
-                "key": name,
-                "bucket": settings.BUCKET_NAME,
-            },
+            json={"key": name},
         )
         if response.status_code != 201:
             raise ValueError(response.text)

--- a/django_app/redbox_app/redbox_core/info_views.py
+++ b/django_app/redbox_app/redbox_core/info_views.py
@@ -9,6 +9,7 @@ import environ
 
 env = environ.Env()
 
+
 @require_http_methods(["GET"])
 def privacy_notice_view(request):
     return render(request, "privacy-notice.html", {})


### PR DESCRIPTION
## Context

As an integrator I want it to be clear what payload i should be posting to 
## Changes proposed in this pull request

before this change it was possible to POST details like the `uuid` which we want to be worked out by the server itself and the swagger doc example payload looked like this
![image](https://github.com/i-dot-ai/redbox-copilot/assets/8233643/4b78edd5-c436-48ce-85ae-649fd8b3c502)

now it looks like

![image](https://github.com/i-dot-ai/redbox-copilot/assets/8233643/7d630f9d-4fc5-4aa8-8a38-65e0abd9418c)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/8734771616
