### PR TITLE
feature/switched to having one sg per ecs service

### DIFF
--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -16,16 +16,6 @@ locals {
   }
 }
 
-resource "aws_security_group" "service_security_group" {
-  vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_id
-  description = "${var.project_name} ${terraform.workspace} ecs security group"
-  name        = "${var.project_name}-${terraform.workspace}"
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-
 module "cluster" {
   source         = "../../../i-ai-core-infrastructure//modules/ecs_cluster"
   project_prefix = var.project_name
@@ -70,7 +60,6 @@ module "core_api" {
   host                         = local.host
   ip_whitelist                 = var.external_ips
   environment_variables        = local.environment_variables
-  security_group_id            = aws_security_group.service_security_group.id
 }
 
 
@@ -100,7 +89,6 @@ module "embedder" {
   host                         = local.host
   ip_whitelist                 = var.external_ips
   environment_variables        = local.environment_variables
-  security_group_id            = aws_security_group.service_security_group.id
 }
 
 
@@ -130,5 +118,4 @@ module "ingester" {
   host                         = local.host
   ip_whitelist                 = var.external_ips
   environment_variables        = local.environment_variables
-  security_group_id            = aws_security_group.service_security_group.id
 }

--- a/infrastructure/aws/elasticache.tf
+++ b/infrastructure/aws/elasticache.tf
@@ -5,6 +5,11 @@ module "elasticache" {
   prefix            = "backend"
   vpc_id            = data.terraform_remote_state.vpc.outputs.vpc_id
   private_subnets   = data.terraform_remote_state.vpc.outputs.private_subnets
-  security_group_id = aws_security_group.service_security_group.id
-
+  security_group_ids = tomap(
+    {
+      "ingester" = module.ingester.ecs_sg_id,
+      "core_api" = module.core_api.ecs_sg_id,
+      "embedder" = module.embedder.ecs_sg_id,
+    }
+  )
 }


### PR DESCRIPTION
## Context

As an engineer I want each ECS Service to always have one SG.

## Changes proposed in this pull request

* all ECS services now have an SG
* the Elasticache service now accepts many ECS SGs
* https://github.com/i-dot-ai/i-ai-core-infrastructure/pull/227

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
