### PR TITLE
bugfix/extend s3 access to ingester and embedder

### DIFF
--- a/infrastructure/aws/iam.tf
+++ b/infrastructure/aws/iam.tf
@@ -35,6 +35,13 @@ resource "aws_iam_policy" "redbox_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "redbox_role_policy" {
-  role       = module.core_api.ecs_task_execution_exec_role_name
+  for_each = tomap(
+    {
+      "core-api"=module.core_api.ecs_task_execution_exec_role_name,
+      "ingester"=module.ingester.ecs_task_execution_exec_role_name,
+      "embedder"=module.embedder.ecs_task_execution_exec_role_name,
+    }
+  )
+  role       = each.value
   policy_arn = aws_iam_policy.redbox_policy.arn
 }


### PR DESCRIPTION
## Context

as an engineer i want the `embedder` and `ingester` to have access to s3 so that they can embed and ingest files

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
