### PR TITLE
Add a basic sessions page

### DIFF
--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -144,3 +144,22 @@ def remove_doc_view(request, doc_id: str):
         template_name="remove-doc.html",
         context={"request": request, "doc_id": doc_id, "doc_name": doc_name},
     )
+
+
+def sessions_view(request, session_id: str = ""):
+
+    # Hard-coding some chat history for now
+    session_history = [
+        {"session_id": "chat1", "title": "Chat 1", "url": "/sessions/chat1"},
+        {"session_id": "chat2", "title": "Chat 2", "url": "/sessions/chat2"},
+    ]
+
+    context = {
+        "session_history": session_history
+    }
+
+    return render(
+        request,
+        template_name="sessions.html",
+        context=context,
+    )

--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -47,6 +47,23 @@
         <a href="/" class="govuk-header__link govuk-header__service-name">
           Redbox Copilot
         </a>
+        <nav aria-label="Menu" class="govuk-header__navigation">
+          <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" hidden>
+            Menu
+          </button>
+          {% set menu_items = [
+            {"text": "Documents", "url": "/documents"},
+            {"text": "Sessions", "url": "/sessions"},
+            {"text": "Sign out", "url": "/"}
+          ] %}
+          <ul id="navigation" class="govuk-header__navigation-list">
+            {% for menu_item in menu_items %}
+              <li class="govuk-header__navigation-item {% if pageTitle == menu_item.text %}govuk-header__navigation-item--active{% endif %}">
+                <a class="govuk-header__link" href="{{ menu_item.url }}">{{ menu_item.text }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        </nav>
       </div>
     </div>
   </header>

--- a/django_app/redbox_app/templates/homepage.html
+++ b/django_app/redbox_app/templates/homepage.html
@@ -2,5 +2,6 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h1 class="govuk-heading-xl">Home Page</h1>
+<h1 class="govuk-heading-xl">Welcome</h1>
+<p class="govuk-body">If you have an account, please <a class="govuk-link" href="/sign-in">sign in</a> to get started</p>
 {% endblock %}

--- a/django_app/redbox_app/templates/sessions.html
+++ b/django_app/redbox_app/templates/sessions.html
@@ -1,0 +1,65 @@
+{% set pageTitle = "Chat" %}
+{% extends "base.html" %}
+{% from "macros/govuk-button.html" import govukButton %}
+
+{% block content %}
+
+{% compress js %}
+  <script src="{{ static('js/alpine.min.js') }}"></script>
+{% endcompress %}
+
+<div class="govuk-grid-row govuk-!-margin-top-3">
+
+  <div class="govuk-grid-column-one-third">
+
+      {{ govukButton(
+        text="Start a new session",
+        href="/sessions",
+        classes="govuk-button--secondary"
+      ) }}
+    
+      <h2 class="govuk-heading-s">Recent sessions</h2>
+      <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+          {% for session in session_history %}
+            <li>
+              <a class="govuk-link" href="{{ session.url }}">{{ session.title }}</a>
+            </li>
+          {% endfor %}
+      </ul>
+      
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-m">Current session</h2>
+
+      <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+              <span class="govuk-visually-hidden">Warning</span>
+              You must check the response for accuracy
+          </strong>
+      </div>
+
+      <form class="iai-new-message js-send-message" action="/sessions/" method="post">
+
+        <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+        <div class="govuk-form-group">
+          <label class="govuk-label" for="message">
+            Write a message
+          </label>
+          <textarea class="govuk-textarea" id="message" name="message" rows="5" required></textarea>
+        </div>
+
+        {{ govukButton(
+          text="Send"
+        ) }}
+
+      </form>
+
+  </div>
+
+</div>
+
+{% endblock %}

--- a/django_app/redbox_app/urls.py
+++ b/django_app/redbox_app/urls.py
@@ -20,6 +20,8 @@ other_urlpatterns = [
     path("documents/", views.documents_view, name="documents"),
     path("upload/", views.upload_view, name="upload"),
     path("remove-doc/<str:doc_id>", views.remove_doc_view, name="remove_doc"),
+    path("sessions/<str:session_id>/", views.sessions_view, name="sessions"),
+    path("sessions/", views.sessions_view, name="sessions"),
 ]
 
 urlpatterns = info_urlpatterns + other_urlpatterns


### PR DESCRIPTION
## Context

This is a basic not-yet-functional sessions page, and top-nav menu items. Just to get something in for us to build upon, and to give us something to work with when starting on the auth.


## Changes proposed in this pull request

* Add top-nav menu items
* Add the sessions page


## Guidance to review

* The first two top-nav menu items should work (ignore "sign-out" for now)
* The sessions page should show 2 previous sessions (currently hard-coded in the view) but not be functional
