### PR TITLE
feature/integration test extended to cover RAG

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,10 +48,13 @@ jobs:
         poetry-version: 1.7.0
 
     - name: Build Containers
+      env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       run: |
         mkdir -p data/elastic/
         chmod -R 777 data/
         cp .env.integration .env
+        sed -i~ "/^OPENAI_API_KEY=/s/=.*/=$OPENAI_API_KEY/" .env
         docker compose up -d --wait core-api embedder ingester
 
     - name: Wait 60s for services to be ready

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,4 +1,5 @@
 import os
+import re
 import time
 
 import pytest
@@ -7,10 +8,15 @@ import requests
 # TODO: add e2e tests involving the Django app, checking S3 upload
 
 
-def test_upload_to_elastic(file_path, s3_client):
+def test_upload_to_search(file_path, s3_client):
     """
     When I POST file data to core-api/file
-    I Expect a Chunk with a non-null embedding ... eventually
+    I Expect:
+        the file to be chunked
+        embeddings to be produced for all chunks
+    And,
+    When I ask a question relevant to my file
+    I expect the file to be cited in the response
     """
 
     with open(file_path, "rb") as f:
@@ -37,13 +43,30 @@ def test_upload_to_elastic(file_path, s3_client):
         timeout = 120
         start_time = time.time()
         error = None
+        embedding_complete = False
 
         while time.time() - start_time < timeout:
             time.sleep(1)
             chunk_response = requests.get(f"http://localhost:5002/file/{file_uuid}/status")
             if chunk_response.status_code == 200 and chunk_response.json()["processing_status"] == "complete":
-                return  # test passed
+                embedding_complete = True
+                break  # test passed
             else:
                 error = chunk_response.text
 
-        pytest.fail(reason=f"failed to get embedded chunks within {timeout} seconds, potential error: {error}")
+        if not embedding_complete:
+            pytest.fail(reason=f"failed to get embedded chunks within {timeout} seconds, potential error: {error}")
+
+        rag_response = requests.post(
+            "http://localhost:5002/chat/rag",
+            json={
+                "message_history": [
+                    {"role": "system", "text": "You are a helpful AI Assistant"},
+                    {"role": "user", "text": "Who is the prime minister"},
+                ]
+            },
+        )
+        assert rag_response.status_code == 200
+        response_message_text = rag_response.json()["response_message"]["text"]
+        assert "Rishi Sunak" in response_message_text
+        assert re.findall(r"<Doc\w{8}-\w{4}-\w{4}-\w{4}-\w{12}>", response_message_text)


### PR DESCRIPTION
## Context

As a front end engineer i want to test that i can query a document that i have uploaded so that i can be confident that the backend hasnt changed

## Changes proposed in this pull request

I have extended the e2e test to include a test for RAG

## Guidance to review

Do not merge until:
 - [ ] the RAG endpoint is in main
 - [ ] `OPENAI_API_KEY` has been added to github secrets
 - [ ] this workflow has been tested

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
