### PR TITLE
Build auth templates

### DIFF
--- a/django_app/redbox_app/redbox_core/auth_views.py
+++ b/django_app/redbox_app/redbox_core/auth_views.py
@@ -1,0 +1,25 @@
+from django.shortcuts import render
+
+
+def sign_in_view(request):
+    return render(
+        request,
+        template_name="sign-in.html",
+        context={"request": request},
+    )
+
+
+def sign_in_link_sent_view(request):
+    return render(
+        request,
+        template_name="sign-in-link-sent.html",
+        context={"request": request},
+    )
+
+
+def signed_out_view(request):
+    return render(
+        request,
+        template_name="signed-out.html",
+        context={"request": request},
+    )

--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -54,7 +54,7 @@
           {% set menu_items = [
             {"text": "Documents", "url": "/documents"},
             {"text": "Sessions", "url": "/sessions"},
-            {"text": "Sign out", "url": "/"}
+            {"text": "Sign out", "url": "/signed-out"}
           ] %}
           <ul id="navigation" class="govuk-header__navigation-list">
             {% for menu_item in menu_items %}

--- a/django_app/redbox_app/templates/magic_link/error.html
+++ b/django_app/redbox_app/templates/magic_link/error.html
@@ -1,0 +1,18 @@
+{% set pageTitle = "Sign in - confirmation" %}
+
+{% extends "base.html" %}
+{% from "macros/govuk-button.html" import govukButton %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">Sign in - error</h1>
+    <p class="govuk-body">There was a problem signing in: {{ error }}</p>
+    <p class="govuk-body">Please try to <a class="govuk-link" href="{{ url('sign_in') }}">sign in</a> again.</p>
+  
+  </div>
+</div>
+
+{% endblock %}

--- a/django_app/redbox_app/templates/magic_link/logmein.html
+++ b/django_app/redbox_app/templates/magic_link/logmein.html
@@ -1,0 +1,24 @@
+{% set pageTitle = "Sign in - confirmation" %}
+
+{% extends "base.html" %}
+{% from "macros/govuk-button.html" import govukButton %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">Sign in - confirmation</h1>
+
+    <form method="POST" action="{{ link.get_absolute_url }}">
+
+      <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+      {{ govukButton(text="Sign in") }}
+
+    </form>
+  
+  </div>
+</div>
+
+{% endblock %}

--- a/django_app/redbox_app/templates/sign-in-link-sent.html
+++ b/django_app/redbox_app/templates/sign-in-link-sent.html
@@ -1,0 +1,17 @@
+{% set pageTitle = "Sign in - link sent" %}
+
+{% extends "base.html" %}
+{% from "macros/govuk-button.html" import govukButton %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">Sign in - link sent</h1>
+    <p class="govuk-body">If you have previously registered, please check your emails for a link to sign in.</p>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/django_app/redbox_app/templates/sign-in.html
+++ b/django_app/redbox_app/templates/sign-in.html
@@ -1,0 +1,34 @@
+{% set pageTitle = "Sign in" %}
+
+{% extends "base.html" %}
+{% from "macros/govuk-button.html" import govukButton %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">Sign in</h1>
+
+    <form action="/sign-in-link-sent">
+
+      <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
+
+      <div class="govuk-form-group">
+        <label class="govuk-label" for="email">
+          Email address
+        </label>
+        <div id="email-hint" class="govuk-hint">
+          Enter your email address to generate a link to sign in
+        </div>
+        <input class="govuk-input" id="email" name="email" type="email" spellcheck="false" aria-describedby="email-hint" autocomplete="email" required>
+      </div>
+
+      {{ govukButton(text="Continue") }}
+
+    </form>
+  
+  </div>
+</div>
+
+{% endblock %}

--- a/django_app/redbox_app/templates/signed-out.html
+++ b/django_app/redbox_app/templates/signed-out.html
@@ -1,0 +1,17 @@
+{% set pageTitle = "Signed out" %}
+
+{% extends "base.html" %}
+{% from "macros/govuk-button.html" import govukButton %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <h1 class="govuk-heading-l">You are signed out</h1>
+    <p class="govuk-body">To continue working please <a class="govuk-link" href="{{ url('sign_in') }}">sign in</a>.</p>
+
+  </div>
+</div>
+
+{% endblock %}

--- a/django_app/redbox_app/urls.py
+++ b/django_app/redbox_app/urls.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.urls import include, path
 
-from .redbox_core import info_views, views
+from .redbox_core import info_views, auth_views, views
 
 info_urlpatterns = [
     path("privacy-notice/", info_views.privacy_notice_view, name="privacy-notice"),
@@ -11,6 +11,12 @@ info_urlpatterns = [
         name="accessibility-statement",
     ),
     path("support/", info_views.support_view, name="support"),
+]
+
+auth_urlpatterns = [
+    path("sign-in/", auth_views.sign_in_view, name="sign_in"),
+    path("sign-in-link-sent/", auth_views.sign_in_link_sent_view, name="sign_in_link_sent"),
+    path("signed-out/", auth_views.signed_out_view, name="signed_out"),
 ]
 
 other_urlpatterns = [
@@ -24,4 +30,4 @@ other_urlpatterns = [
     path("sessions/", views.sessions_view, name="sessions"),
 ]
 
-urlpatterns = info_urlpatterns + other_urlpatterns
+urlpatterns = info_urlpatterns + auth_urlpatterns + other_urlpatterns


### PR DESCRIPTION
## Context

This is creating the Jinja templates to support @252afh's work on authentication.

## Changes proposed in this pull request

Creating the following pages:
* /sign-in
* /sign-in-link-sent
* /signed-out
* 2 x magic_link pages 

## Guidance to review

* The first 3 pages are able to be checked now, but not functional
* The other 2 pages will be visible once magic_link has been added in, but a quick glance at the HTML to check they're a sensible starting point would be good.
