### PR TITLE
Add file upload endpoint for testing

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6651,4 +6651,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "42c159ac81cfca5e27e0fb770d7aa5900dc006a82eab6cefb1ced5a468430a8d"
+content-hash = "c33e01f83e5c31f00356ab51b1f31eae4030666d797528da67e55b2afed1ad3b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ fastapi = "^0.110.1"
 faststream = {extras = ["redis"], version = "<0.5.0"}
 uvicorn = "^0.29.0"
 langchain-elasticsearch = "^0.1.2"
+python-multipart = "^0.0.9"
 
 [tool.poetry.group.worker.dependencies]
 unstructured = {version = "0.13.3", extras = ["all-docs"]}


### PR DESCRIPTION
## Context

As a developer I want to quickly be able to upload a file to test the processing when in dev mode

## Changes proposed in this pull request

<img width="1477" alt="Screenshot 2024-04-26 at 17 56 56" src="https://github.com/i-dot-ai/redbox-copilot/assets/146714503/d86cf7b0-0ca4-43c3-abe3-33c520f8ad55">

## Guidance to review

Set `DEV_MODE=true` in .env
`make run`
Go to http://localhost:5002/file/docs#/file/upload_file_upload_post
Upload a file
Watch it appear in Minio and later in Elasticsearch

## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
