### PR TITLE
Feature/redbox 200 move sources to a separate field for chat endpoint responses

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -67,6 +67,12 @@ jobs:
         pip install boto3
         python -m pytest tests
 
+    - name: get-logs
+      uses: slackapi/slack-github-action@v1.24.0
+      if: ${{ failure() }}
+      run: |
+        docker compose logs core-api
+
     - name: notify slack failure
       id: slack-failure
       uses: slackapi/slack-github-action@v1.24.0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -68,7 +68,6 @@ jobs:
         python -m pytest tests
 
     - name: get-logs
-      uses: slackapi/slack-github-action@v1.24.0
       if: ${{ failure() }}
       run: |
         docker compose logs core-api

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -67,11 +67,6 @@ jobs:
         pip install boto3
         python -m pytest tests
 
-    - name: get-logs
-      if: ${{ failure() }}
-      run: |
-        docker compose logs -f core-api worker
-
     - name: notify slack failure
       id: slack-failure
       uses: slackapi/slack-github-action@v1.24.0

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -70,7 +70,7 @@ jobs:
     - name: get-logs
       if: ${{ failure() }}
       run: |
-        docker compose logs core-api
+        docker compose logs -f core-api worker
 
     - name: notify slack failure
       id: slack-failure

--- a/core_api/src/routes/chat.py
+++ b/core_api/src/routes/chat.py
@@ -149,5 +149,5 @@ def rag_chat(chat_request: ChatRequest) -> ChatResponse:
         },
     )
 
-    result["input_documents"] = [input_document.dict() for input_document in result["input_documents"]]
-    return ChatResponse(**result)
+    sources = [input_document.dict() for input_document in result.pop("input_documents", [])]
+    return ChatResponse(output_text=result["output_text"], sources=sources)

--- a/core_api/src/routes/chat.py
+++ b/core_api/src/routes/chat.py
@@ -150,7 +150,11 @@ def rag_chat(chat_request: ChatRequest) -> ChatResponse:
     )
 
     source_documents = [
-        SourceDocument.from_langchain_document(langchain_document)
+        SourceDocument(
+            page_content=langchain_document.page_content,
+            file_uuid=langchain_document.metadata.get("parent_doc_uuid"),
+            page_numbers=langchain_document.metadata.get("page_numbers"),
+        )
         for langchain_document in result.get("input_documents", [])
     ]
     return ChatResponse(output_text=result["output_text"], source_documents=source_documents)

--- a/core_api/src/routes/chat.py
+++ b/core_api/src/routes/chat.py
@@ -14,7 +14,7 @@ from redbox.llm.prompts.chat import (
 )
 from redbox.model_db import MODEL_PATH
 from redbox.models import Settings, EmbeddingModelInfo
-from redbox.models.chat import ChatRequest, ChatResponse, ChatMessage
+from redbox.models.chat import ChatRequest, ChatResponse, ChatMessage, SourceDocument
 
 # === Logging ===
 
@@ -149,5 +149,8 @@ def rag_chat(chat_request: ChatRequest) -> ChatResponse:
         },
     )
 
-    sources = [input_document.dict() for input_document in result.pop("input_documents", [])]
-    return ChatResponse(output_text=result["output_text"], sources=sources)
+    source_documents = [
+        SourceDocument.from_langchain_document(langchain_document)
+        for langchain_document in result.get("input_documents", [])
+    ]
+    return ChatResponse(output_text=result["output_text"], source_documents=source_documents)

--- a/core_api/src/routes/chat.py
+++ b/core_api/src/routes/chat.py
@@ -112,7 +112,7 @@ def simple_chat(chat_request: ChatRequest) -> ChatResponse:
     return ChatResponse(response_message=ChatMessage(text=response.text, role="ai"))
 
 
-@chat_app.post("/rag", tags=["chat"], response_model=ChatResponse)
+@chat_app.post("/rag", tags=["chat"])
 def rag_chat(chat_request: ChatRequest) -> ChatResponse:
     """Get a LLM response to a question history and file
 
@@ -149,4 +149,5 @@ def rag_chat(chat_request: ChatRequest) -> ChatResponse:
         },
     )
 
-    return ChatResponse(response_message=ChatMessage(text=result["output_text"], role="ai"))
+    result["input_documents"] = [input_document.dict() for input_document in result["input_documents"]]
+    return ChatResponse(**result)

--- a/redbox/models/chat.py
+++ b/redbox/models/chat.py
@@ -1,7 +1,6 @@
 from typing import Literal, Optional
 from uuid import UUID
 
-from langchain_core.documents import Document
 from pydantic import Field, BaseModel
 
 
@@ -43,15 +42,6 @@ class SourceDocument(BaseModel):
     page_numbers: Optional[list[int]] = Field(
         description="page number of the file that this chunk came from", default=None
     )
-
-    @classmethod
-    def from_langchain_document(cls, langchain_document: Document):
-        """typically we construct this class from a langchain.Document"""
-        source_document = SourceDocument(page_content=langchain_document.page_content)
-        if langchain_document.metadata:
-            source_document.file_uuid = langchain_document.metadata["parent_doc_uuid"]
-            source_document.page_numbers = langchain_document.metadata["page_numbers"]
-        return source_document
 
 
 class ChatResponse(BaseModel):

--- a/redbox/models/chat.py
+++ b/redbox/models/chat.py
@@ -1,7 +1,7 @@
 from typing import Literal, Optional
 from uuid import UUID
 
-from pydantic import Field, BaseModel, AnyUrl, conlist
+from pydantic import Field, BaseModel, AnyUrl
 
 
 class ChatMessage(BaseModel):
@@ -36,23 +36,10 @@ class ChatRequest(BaseModel):
     }
 
 
-class Coordinates(BaseModel):
-    layout_width: int = Field(description="width")
-    layout_height: int = Field(description="height")
-    system: str = Field(description="layout unit", examples=["PixelSpace"])
-    points: list[conlist(float, min_length=2, max_length=2)] = None
-
-
 class Metadata(BaseModel):
     languages: list[str] = Field(description="languages detected in this chunk", examples=[["eng"]])
-    coordinates: Coordinates
-    parent_id: UUID
     url: AnyUrl = Field(description="url of original file")
-    orig_elements: list[str]
-    text_as_html: list[str]
-    is_continuation: bool
     filetype: str = Field(description="content-type", examples=["application/pdf"])
-    detection_class_prob: float
     parent_doc_uuid: UUID = Field(description="uuid of original file")
     page_numbers: list[int] = Field(description="page number of the file that this chunk came from")
 
@@ -67,7 +54,7 @@ class ChatResponse(BaseModel):
         description="original question",
         examples=["Who is the prime minister?"],
     )
-    input_documents: Optional[InputDocuments] = Field(
+    input_documents: Optional[list[InputDocuments]] = Field(
         description="documents retrieved to form this response", default=None
     )
     output_text: str = Field(

--- a/redbox/models/chat.py
+++ b/redbox/models/chat.py
@@ -37,11 +37,15 @@ class ChatRequest(BaseModel):
 
 
 class Metadata(BaseModel):
-    languages: list[str] = Field(description="languages detected in this chunk", examples=[["eng"]])
-    url: AnyUrl = Field(description="url of original file")
-    filetype: str = Field(description="content-type", examples=["application/pdf"])
     parent_doc_uuid: UUID = Field(description="uuid of original file")
-    page_numbers: list[int] = Field(description="page number of the file that this chunk came from")
+    languages: Optional[list[str]] = Field(
+        description="languages detected in this chunk", examples=[["eng"]], default=None
+    )
+    url: Optional[AnyUrl] = Field(description="url of original file", default=None)
+    filetype: Optional[str] = Field(description="content-type", examples=["application/pdf"], default=None)
+    page_numbers: Optional[list[int]] = Field(
+        description="page number of the file that this chunk came from", default=None
+    )
 
 
 class InputDocuments(BaseModel):

--- a/redbox/models/chat.py
+++ b/redbox/models/chat.py
@@ -1,7 +1,7 @@
 from typing import Literal, Optional
 from uuid import UUID
 
-from pydantic import Field, BaseModel, AnyUrl
+from pydantic import Field, BaseModel
 
 
 class ChatMessage(BaseModel):
@@ -38,11 +38,6 @@ class ChatRequest(BaseModel):
 
 class Metadata(BaseModel):
     parent_doc_uuid: UUID = Field(description="uuid of original file")
-    languages: Optional[list[str]] = Field(
-        description="languages detected in this chunk", examples=[["eng"]], default=None
-    )
-    url: Optional[AnyUrl] = Field(description="url of original file", default=None)
-    filetype: Optional[str] = Field(description="content-type", examples=["application/pdf"], default=None)
     page_numbers: Optional[list[int]] = Field(
         description="page number of the file that this chunk came from", default=None
     )
@@ -54,11 +49,7 @@ class InputDocuments(BaseModel):
 
 
 class ChatResponse(BaseModel):
-    question: str = Field(
-        description="original question",
-        examples=["Who is the prime minister?"],
-    )
-    input_documents: Optional[list[InputDocuments]] = Field(
+    sources: Optional[list[InputDocuments]] = Field(
         description="documents retrieved to form this response", default=None
     )
     output_text: str = Field(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,17 +49,11 @@ def pytest_runtest_makereport(item, call):
             # retrieve the class name of the test
             cls_name = str(item.cls)
             # retrieve the index of the test (if parametrize is used in combination with incremental)
-            parametrize_index = (
-                tuple(item.callspec.indices.values())
-                if hasattr(item, "callspec")
-                else ()
-            )
+            parametrize_index = tuple(item.callspec.indices.values()) if hasattr(item, "callspec") else ()
             # retrieve the name of the test function
             test_name = item.originalname or item.name
             # store in _test_failed_incremental the original name of the failed test
-            _test_failed_incremental.setdefault(cls_name, {}).setdefault(
-                parametrize_index, test_name
-            )
+            _test_failed_incremental.setdefault(cls_name, {}).setdefault(parametrize_index, test_name)
 
 
 def pytest_runtest_setup(item):
@@ -69,11 +63,7 @@ def pytest_runtest_setup(item):
         # check if a previous test has failed for this class
         if cls_name in _test_failed_incremental:
             # retrieve the index of the test (if parametrize is used in combination with incremental)
-            parametrize_index = (
-                tuple(item.callspec.indices.values())
-                if hasattr(item, "callspec")
-                else ()
-            )
+            parametrize_index = tuple(item.callspec.indices.values()) if hasattr(item, "callspec") else ()
             # retrieve the name of the first test function to fail for this class name and index
             test_name = _test_failed_incremental[cls_name].get(parametrize_index, None)
             # if name found, test has failed for the combination of class name & test name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,3 +35,47 @@ def s3_client():
             raise e
 
     yield client
+
+
+# store history of failures per test class name and per index in parametrize (if parametrize used)
+_test_failed_incremental: dict[str, dict[tuple[int, ...], str]] = {}
+
+
+def pytest_runtest_makereport(item, call):
+    if "incremental" in item.keywords:
+        # incremental marker is used
+        if call.excinfo is not None:
+            # the test has failed
+            # retrieve the class name of the test
+            cls_name = str(item.cls)
+            # retrieve the index of the test (if parametrize is used in combination with incremental)
+            parametrize_index = (
+                tuple(item.callspec.indices.values())
+                if hasattr(item, "callspec")
+                else ()
+            )
+            # retrieve the name of the test function
+            test_name = item.originalname or item.name
+            # store in _test_failed_incremental the original name of the failed test
+            _test_failed_incremental.setdefault(cls_name, {}).setdefault(
+                parametrize_index, test_name
+            )
+
+
+def pytest_runtest_setup(item):
+    if "incremental" in item.keywords:
+        # retrieve the class name of the test
+        cls_name = str(item.cls)
+        # check if a previous test has failed for this class
+        if cls_name in _test_failed_incremental:
+            # retrieve the index of the test (if parametrize is used in combination with incremental)
+            parametrize_index = (
+                tuple(item.callspec.indices.values())
+                if hasattr(item, "callspec")
+                else ()
+            )
+            # retrieve the name of the first test function to fail for this class name and index
+            test_name = _test_failed_incremental[cls_name].get(parametrize_index, None)
+            # if name found, test has failed for the combination of class name & test name
+            if test_name is not None:
+                pytest.xfail("previous test failed ({})".format(test_name))

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,6 +1,5 @@
 import os
 import time
-from typing import Optional
 
 import pytest
 import requests
@@ -19,10 +18,10 @@ class TestEndToEnd:
     When I ask a question relevant to my file
     I expect the file to be cited in the response
     """
+
     file_uuid: str = None
 
     def test_upload_to_search(self, file_path, s3_client):
-
         with open(file_path, "rb") as f:
             file_key = os.path.basename(file_path)
             file_type = os.path.splitext(file_key)[-1]
@@ -77,7 +76,5 @@ class TestEndToEnd:
             },
         )
         assert rag_response.status_code == 200
-        parent_doc_uuids = {
-            input_document["metadata"]["parent_doc_uuid"] for input_document in rag_response.json()["input_documents"]
-        }
+        parent_doc_uuids = {source["metadata"]["parent_doc_uuid"] for source in rag_response.json()["sources"]}
         assert TestEndToEnd.file_uuid in parent_doc_uuids

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -76,5 +76,7 @@ class TestEndToEnd:
             },
         )
         assert rag_response.status_code == 200
-        parent_doc_uuids = {source["metadata"]["parent_doc_uuid"] for source in rag_response.json()["sources"]}
-        assert TestEndToEnd.file_uuid in parent_doc_uuids
+        source_document_file_uuids = {
+            source_document["file_uuid"] for source_document in rag_response.json()["source_documents"]
+        }
+        assert TestEndToEnd.file_uuid in source_document_file_uuids


### PR DESCRIPTION
## Context

As a frontend I want the backed to return as much information as possible., i.e. the uuid of the original file.

## Changes proposed in this pull request

* I have extended the `ChatResponse` to return the full langchain response
* I have extended the test to check that the original document is returned
* I have switched to the incremental test approach (thx @wpfl-dbt)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-200
## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/8910714772/job/24470508092