### PR TITLE
feature/remove-embeedding-endpoint

### DIFF
--- a/core_api/Dockerfile
+++ b/core_api/Dockerfile
@@ -11,7 +11,6 @@ ENV POETRY_NO_INTERACTION=1 \
 # Add redbox python package and install it with poetry
 ADD redbox/ /app/redbox
 ADD pyproject.toml poetry.lock /app/
-ADD download_embedder.py /app/
 ADD redbox/ /app/redbox
 
 RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install --no-root --no-ansi --with api,ai --without worker,dev
@@ -26,11 +25,7 @@ ENV VIRTUAL_ENV=/app/.venv \
 COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 COPY core_api/ /app/core_api/
-ADD download_embedder.py /app/
 ADD redbox/ /app/redbox
-
-# Download the model
-RUN type=cache python download_embedder.py --embedding_model ${EMBEDDING_MODEL}
 
 # Run FastAPI
 EXPOSE 5002

--- a/core_api/src/app.py
+++ b/core_api/src/app.py
@@ -5,13 +5,11 @@ from fastapi.responses import RedirectResponse
 
 from core_api.src.routes.chat import chat_app
 from core_api.src.routes.file import file_app
-from redbox.model_db import SentenceTransformerDB
-from redbox.models import EmbeddingResponse, EmbeddingModelInfo, Settings, StatusResponse
+from redbox.models import Settings, StatusResponse
 
 # === Logging ===
 
 env = Settings()
-model_db = SentenceTransformerDB(env.embedding_model)
 
 
 # === API Setup ===
@@ -62,31 +60,6 @@ def health() -> StatusResponse:
     )
 
     return output
-
-
-@app.get("/embedding_model", tags=["embedding"])
-def get_embedding_model() -> EmbeddingModelInfo:
-    """Returns information about the model
-
-    Returns:
-        EmbeddingModelInfo: Information about the model
-    """
-
-    return model_db.get_embedding_model_info()
-
-
-@app.post("/embedding", tags=["embedding"])
-def embed_sentences(sentences: list[str]) -> EmbeddingResponse:
-    """Embeds a list of sentences using a given model
-
-    Args:
-        sentences (list[str]): A list of sentences
-
-    Returns:
-        EmbeddingResponse: The embeddings of the sentences
-    """
-
-    return model_db.embed_sentences(sentences)
 
 
 app.mount("/chat", chat_app)

--- a/core_api/tests/test_app.py
+++ b/core_api/tests/test_app.py
@@ -1,6 +1,3 @@
-from core_api.src.app import env
-
-
 def test_get_health(app_client):
     """
     Given that the app is running
@@ -8,48 +5,4 @@ def test_get_health(app_client):
     I Expect to see the docs
     """
     response = app_client.get("/health")
-    assert response.status_code == 200
-
-
-def test_read_model(client):
-    """
-    Given that I have a model in the database
-    When I GET /embedding_model
-    I Expect model-info to be returned
-    """
-    response = client.get("/embedding_model")
-    assert response.status_code == 200
-    assert response.json() == {
-        "embedding_model": env.embedding_model,
-        "vector_size": 768,
-    }
-
-
-def test_embed_sentences_422(client):
-    """
-    Given that I have a model in the database
-    When I POST a mall-formed payload to /embedding
-    I Expect a 422 error
-    """
-    response = client.post(
-        "/embedding",
-        json={"not": "a well formed payload"},
-    )
-    assert response.status_code == 422
-    assert response.json()["detail"][0]["msg"] == "Input should be a valid list"
-
-
-def test_embed_sentences(client):
-    """
-    Given that I have a model in the database
-    When I POST a valid payload consisting of some sentenced to embed to
-    /embedding
-    I Expect a 200 response
-
-    N.B. We are not testing the content / efficacy of the model in this test.
-    """
-    response = client.post(
-        "/embedding",
-        json=["I am the egg man", "I am the walrus"],
-    )
     assert response.status_code == 200


### PR DESCRIPTION
## Context

As an engineer I want to remove unused endpoints so that we do not have to support them.

## Changes proposed in this pull request

1. I have removed the `/embedding` endpoint
2. I have also removed the `/model` endpoint because this allowed us to remove the embedding model itself which dramatically simplifies the `core-api`

If we really need the `/model` endpoint we could have it return the environment variable `EMBEDDING_MODEL` ?

## Guidance to review

This PR is in 3 parts:
1. remove unneeded endpoints [1ac8062](https://github.com/i-dot-ai/redbox-copilot/pull/300/commits/1ac8062b73f75902cee50b92e069fdb24c241598)
2. remove unused tests https://github.com/i-dot-ai/redbox-copilot/pull/300/commits/b2c0de41727d8acf1eed8e9a4fab891f532e1e22

we could also move the `model_db.py` to the `worker`, or just remove it altogether

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-206

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/8924031416
