### PR TITLE
feature/REDBOX-170-add-jwt-to-core-api

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -65,6 +65,7 @@ jobs:
         pip install requests
         pip install pytest
         pip install boto3
+        pip install python-jose
         python -m pytest tests
 
     - name: notify slack failure

--- a/README.md
+++ b/README.md
@@ -83,6 +83,30 @@ This project is licensed under the MIT License - see the [LICENSE](./LICENSE) fi
 
 # Security
 
+> [!IMPORTANT]
+> The core-api is the http-gateway to the backend. Currently, this is unsecured, you should only run this on
+a private network. 
+
+However:
+* We have taken care to ensure that the backend is as stateless as possible, i.e. it only stores text chunks and 
+  embeddings. All data is associated with a user, and a user can access their own data. 
+* The only user data stored is the user-uuid, and no chat history is stored.
+* We are considering making the core-api secure. To this end the user-uuid is passed to the core-api as a JWT.
+  Currently no attempt is made to verify the JWT, but in the future we may do so, e.g. via Cognito or similar
+
+You can generate your JWT using the following snippet. Note that you whilst you can use a more secure key than an
+empty string this is currently not verified.  
+
+```python
+from jose import jwt
+import requests
+
+my_uuid = "a93a8f40-f261-4f12-869a-2cea3f3f0d71"
+token = jwt.encode({"user_uuid": my_uuid}, key="")
+
+requests.get(..., headers={"Authorization": f"Bearer {token}"})
+```
+
 If you discover a security vulnerability within this project, please follow our [Security Policy](./SECURITY.md).
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This project is licensed under the MIT License - see the [LICENSE](./LICENSE) fi
 
 > [!IMPORTANT]
 > The core-api is the http-gateway to the backend. Currently, this is unsecured, you should only run this on
-a private network. 
+> a private network. 
 
 However:
 * We have taken care to ensure that the backend is as stateless as possible, i.e. it only stores text chunks and 

--- a/core_api/src/auth.py
+++ b/core_api/src/auth.py
@@ -1,0 +1,25 @@
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import HTTPException, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from jose import jwt, JWTError
+from starlette import status
+
+
+http_bearer = HTTPBearer()
+
+
+async def get_user_uuid(token: Annotated[HTTPAuthorizationCredentials, Depends(http_bearer)]) -> UUID:
+    """this extracts the user_uuid for Authorization only,
+    no Authentication is attempted."""
+    try:
+        payload = jwt.get_unverified_claims(token.credentials)
+        return UUID(payload["user_uuid"])
+    except (TypeError, ValueError, KeyError, JWTError):
+        credentials_exception = HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+        raise credentials_exception

--- a/core_api/src/routes/chat.py
+++ b/core_api/src/routes/chat.py
@@ -1,4 +1,7 @@
-from fastapi import FastAPI, HTTPException
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import FastAPI, HTTPException, Depends
 from langchain.chains.llm import LLMChain
 from langchain.chains.qa_with_sources import load_qa_with_sources_chain
 from langchain_community.chat_models import ChatLiteLLM
@@ -7,6 +10,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_elasticsearch import ElasticsearchStore, ApproxRetrievalStrategy
 import logging
 
+from core_api.src.auth import get_user_uuid
 from redbox.llm.prompts.chat import (
     CONDENSE_QUESTION_PROMPT,
     STUFF_DOCUMENT_PROMPT,
@@ -82,7 +86,7 @@ vector_store = ElasticsearchStore(
 
 
 @chat_app.post("/vanilla", tags=["chat"], response_model=ChatResponse)
-def simple_chat(chat_request: ChatRequest) -> ChatResponse:
+def simple_chat(chat_request: ChatRequest, _user_uuid: Annotated[UUID, Depends(get_user_uuid)]) -> ChatResponse:
     """Get a LLM response to a question history"""
 
     if len(chat_request.message_history) < 2:
@@ -113,7 +117,7 @@ def simple_chat(chat_request: ChatRequest) -> ChatResponse:
 
 
 @chat_app.post("/rag", tags=["chat"])
-def rag_chat(chat_request: ChatRequest) -> ChatResponse:
+def rag_chat(chat_request: ChatRequest, _user_uuid: Annotated[UUID, Depends(get_user_uuid)]) -> ChatResponse:
     """Get a LLM response to a question history and file
 
     Args:

--- a/core_api/tests/conftest.py
+++ b/core_api/tests/conftest.py
@@ -1,10 +1,12 @@
 import os
 from typing import Generator, TypeVar
+from uuid import uuid4, UUID
 
 import pytest
 from botocore.exceptions import ClientError
 from elasticsearch import Elasticsearch
 from fastapi.testclient import TestClient
+from jose import jwt
 from sentence_transformers import SentenceTransformer
 
 from core_api.src.app import app as application
@@ -50,6 +52,17 @@ def es_client() -> YieldFixture[Elasticsearch]:
 @pytest.fixture
 def app_client():
     yield TestClient(application)
+
+
+@pytest.fixture
+def user_uuid() -> UUID:
+    yield uuid4()
+
+
+@pytest.fixture
+def headers(user_uuid):
+    bearer_token = jwt.encode({"user_uuid": str(user_uuid)}, key="nvjkernd")
+    yield {"Authorization": f"Bearer {bearer_token}"}
 
 
 @pytest.fixture

--- a/core_api/tests/routes/test_chat.py
+++ b/core_api/tests/routes/test_chat.py
@@ -33,11 +33,11 @@ def mock_get_chain(llm, prompt):
 
 
 @pytest.mark.parametrize("chat_history, status_code", test_history)
-def test_simple_chat(chat_history, status_code, app_client, monkeypatch):
+def test_simple_chat(chat_history, status_code, app_client, monkeypatch, headers):
     monkeypatch.setattr("langchain_core.prompts.ChatPromptTemplate.from_messages", mock_chat_prompt)
     monkeypatch.setattr("core_api.src.routes.chat.LLMChain", mock_get_chain)
 
-    response = app_client.post("/chat/vanilla", json={"message_history": chat_history})
+    response = app_client.post("/chat/vanilla", json={"message_history": chat_history}, headers=headers)
     assert response.status_code == status_code
 
 
@@ -58,11 +58,11 @@ def test_simple_chat(chat_history, status_code, app_client, monkeypatch):
         ),
     ],
 )
-def test_chat_errors(app_client, payload, error):
+def test_chat_errors(app_client, payload, error, headers):
     """Given the app is running
     When I POST a malformed payload to /chat/vanilla
     I expect a 422 error and a meaningful message
     """
-    response = app_client.post("/chat/vanilla", json={"message_history": payload})
+    response = app_client.post("/chat/vanilla", json={"message_history": payload}, headers=headers)
     assert response.status_code == 422
     assert response.json() == error

--- a/core_api/tests/routes/test_file.py
+++ b/core_api/tests/routes/test_file.py
@@ -8,7 +8,7 @@ from core_api.src.routes.file import env, router
 
 
 @pytest.mark.asyncio
-async def test_post_file_upload(s3_client, app_client, elasticsearch_storage_handler, file_pdf_path):
+async def test_post_file_upload(s3_client, app_client, elasticsearch_storage_handler, file_pdf_path, headers):
     """
     Given a new file
     When I POST it to /file
@@ -32,22 +32,22 @@ async def test_post_file_upload(s3_client, app_client, elasticsearch_storage_han
                     "key": file_key,
                     "bucket": env.bucket_name,
                 },
+                headers=headers,
             )
     assert response.status_code == 200
 
 
-def test_get_file(app_client, stored_file):
+def test_get_file(app_client, stored_file, headers):
     """
     Given a previously saved file
     When I GET it from /file/uuid
     I Expect to receive it
     """
-
-    response = app_client.get(f"/file/{stored_file.uuid}")
+    response = app_client.get(f"/file/{stored_file.uuid}", headers=headers)
     assert response.status_code == 200
 
 
-def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, chunked_file):
+def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, chunked_file, headers):
     """
     Given a previously saved file
     When I DELETE it to /file
@@ -58,7 +58,7 @@ def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, chunk
     assert elasticsearch_storage_handler.read_item(item_uuid=chunked_file.uuid, model_type="file")
     assert elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid)
 
-    response = app_client.delete(f"/file/{chunked_file.uuid}")
+    response = app_client.delete(f"/file/{chunked_file.uuid}", headers=headers)
     assert response.status_code == 200
 
     elasticsearch_storage_handler.refresh()
@@ -73,7 +73,7 @@ def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, chunk
     assert not elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid)
 
 
-def test_get_file_chunks(client, chunked_file):
-    response = client.get(f"/file/{chunked_file.uuid}/chunks")
+def test_get_file_chunks(client, chunked_file, headers):
+    response = client.get(f"/file/{chunked_file.uuid}/chunks", headers=headers)
     assert response.status_code == 200
     assert len(response.json()) == 5

--- a/core_api/tests/test_auth.py
+++ b/core_api/tests/test_auth.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-import jwt
+from jose import jwt
 import pytest
 
 

--- a/core_api/tests/test_auth.py
+++ b/core_api/tests/test_auth.py
@@ -1,0 +1,24 @@
+from uuid import uuid4
+
+import jwt
+import pytest
+
+
+@pytest.mark.parametrize(
+    "malformed_headers, status_code",
+    [
+        (None, 403),
+        ({"Authorization": "blah blah"}, 403),
+        ({"Authorization": "Bearer blah-blah"}, 401),
+        ({"Authorization": "Bearer " + jwt.encode({"user_uuid": "not a uuid"}, key="super-secure-private-key")}, 401),
+        ({"Authorization": "Bearer " + jwt.encode({"user_uuid": str(uuid4())}, key="super-secure-private-key")}, 200),
+    ],
+)
+def test_get_file_fails_auth(app_client, stored_file, malformed_headers, status_code):
+    """
+    Given a previously saved file
+    When I GET it from /file/uuid with a missing/broken/correct header
+    I Expect get an appropriate status_code
+    """
+    response = app_client.get(f"/file/{stored_file.uuid}", headers=malformed_headers)
+    assert response.status_code == status_code

--- a/django_app/redbox_app/redbox_core/client.py
+++ b/django_app/redbox_app/redbox_core/client.py
@@ -3,7 +3,7 @@ from botocore.exceptions import ClientError
 from django.conf import settings
 import requests
 
-from django_app.redbox_app.redbox_core.models import User
+from redbox_app.redbox_core.models import User
 
 
 def s3_client():

--- a/django_app/redbox_app/redbox_core/client.py
+++ b/django_app/redbox_app/redbox_core/client.py
@@ -3,6 +3,8 @@ from botocore.exceptions import ClientError
 from django.conf import settings
 import requests
 
+from django_app.redbox_app.redbox_core.models import User
+
 
 def s3_client():
     if settings.OBJECT_STORE == "minio":
@@ -44,7 +46,7 @@ class CoreApiClient:
     def url(self) -> str:
         return f"{self.host}:{self.port}"
 
-    def upload_file(self, name: str):
+    def upload_file(self, name: str, user: User):
         if self.host == "testserver":
             file = {
                 "key": name,
@@ -53,8 +55,7 @@ class CoreApiClient:
             return file
 
         response = requests.post(
-            f"{self.url}/file",
-            json={"key": name},
+            f"{self.url}/file", json={"key": name}, headers={"Authorization": user.get_bearer_token()}
         )
         if response.status_code != 201:
             raise ValueError(response.text)

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -41,7 +41,7 @@ class User(BaseUser, UUIDPrimaryKeyBase):
     def get_bearer_token(self) -> str:
         """the bearer token expected by the core-api"""
         user_uuid = str(self.id)
-        bearer_token = jwt.encode({"user_uuid": user_uuid}, key=settings.DJANGO_SECRET_KEY)
+        bearer_token = jwt.encode({"user_uuid": user_uuid}, key=settings.SECRET_KEY)
         return f"Bearer {bearer_token}"
 
 

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from django_use_email_as_username.models import BaseUser, BaseUserManager
 
 from dotenv import load_dotenv
+from jose import jwt
 
 load_dotenv()
 
@@ -36,6 +37,12 @@ class User(BaseUser, UUIDPrimaryKeyBase):
     def save(self, *args, **kwargs):
         self.email = self.email.lower()
         super().save(*args, **kwargs)
+
+    def get_bearer_token(self) -> str:
+        """the bearer token expected by the core-api"""
+        user_uuid = str(self.id)
+        bearer_token = jwt.encode({"user_uuid": user_uuid}, key=settings.DJANGO_SECRET_KEY)
+        return f"Bearer {bearer_token}"
 
 
 class ProcessingStatusEnum(models.TextChoices):

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -126,7 +126,7 @@ def upload_view(request):
             api = CoreApiClient(host=settings.CORE_API_HOST, port=settings.CORE_API_PORT)
 
             try:
-                api.upload_file(uploaded_file.name)
+                api.upload_file(uploaded_file.name, request.user)
                 # TODO: update improved File object with elastic uuid
                 uploaded = True
             except ValueError as value_error:
@@ -198,7 +198,9 @@ def post_message(request: HttpRequest) -> HttpResponse:
         for message in ChatMessage.objects.all().filter(chat_history=session)
     ]
     url = settings.CORE_API_HOST + ":" + settings.CORE_API_PORT + "/chat/rag"
-    response = requests.post(url, json={"message_history": message_history})
+    response = requests.post(
+        url, json={"message_history": message_history}, headers={"Authorization": request.user.get_bearer_token()}
+    )
     llm_data = response.json()
 
     # save LLM response

--- a/poetry.lock
+++ b/poetry.lock
@@ -1273,6 +1273,24 @@ files = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.19.0"
+description = "ECDSA cryptographic signature library (pure python)"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.6"
+files = [
+    {file = "ecdsa-0.19.0-py2.py3-none-any.whl", hash = "sha256:2cea9b88407fdac7bbeca0833b189e4c9c53f2ef1e1eaa29f6224dbc809b707a"},
+    {file = "ecdsa-0.19.0.tar.gz", hash = "sha256:60eaad1199659900dd0af521ed462b793bbdf867432b3948e87416ae4caf6bf8"},
+]
+
+[package.dependencies]
+six = ">=1.9.0"
+
+[package.extras]
+gmpy = ["gmpy"]
+gmpy2 = ["gmpy2"]
+
+[[package]]
 name = "editorconfig"
 version = "0.12.4"
 description = "EditorConfig File Locator and Interpreter for Python"
@@ -4880,6 +4898,27 @@ files = [
 dev = ["black (==24.4.2)", "build (==1.2.1)", "flake8 (==7.0.0)", "pytest (==8.1.2)", "requests (==2.31.0)", "twine (==5.0.0)"]
 
 [[package]]
+name = "python-jose"
+version = "3.3.0"
+description = "JOSE implementation in Python"
+optional = false
+python-versions = "*"
+files = [
+    {file = "python-jose-3.3.0.tar.gz", hash = "sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a"},
+    {file = "python_jose-3.3.0-py2.py3-none-any.whl", hash = "sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a"},
+]
+
+[package.dependencies]
+ecdsa = "!=0.15"
+pyasn1 = "*"
+rsa = "*"
+
+[package.extras]
+cryptography = ["cryptography (>=3.4.0)"]
+pycrypto = ["pyasn1", "pycrypto (>=2.6.0,<2.7.0)"]
+pycryptodome = ["pyasn1", "pycryptodome (>=3.3.1,<4.0.0)"]
+
+[[package]]
 name = "python-magic"
 version = "0.4.27"
 description = "File type identification using libmagic"
@@ -6869,4 +6908,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "7785f2041fa98fadd2b9ec7ffc4022256571ed8e6cd8f6833b072ad5431e24dc"
+content-hash = "139923bef2eba8df2a880aa2f0bb9816ca0953175f71f07ca19d4762f25a6038"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ faststream = {extras = ["redis"], version = "<0.5.0"}
 uvicorn = "^0.29.0"
 langchain-elasticsearch = "^0.1.2"
 python-multipart = "^0.0.9"
+python-jose = "^3.3.0"
 
 [tool.poetry.group.worker.dependencies]
 opencv-python-headless = "^4.9.0.80"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def s3_client():
 @pytest.fixture
 def headers():
     user_uuid = uuid4()
-    token = jwt.encode({"user_uuid": str(user_uuid)})
+    token = jwt.encode({"user_uuid": str(user_uuid)}, key="super-secure-private-key")
     yield {"Authorization": f"Bearer {token}"}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 import os
+from uuid import uuid4
 
 import boto3
 import pytest
 from botocore.exceptions import ClientError
+from jose import jwt
 
 
 @pytest.fixture
@@ -35,6 +37,13 @@ def s3_client():
             raise e
 
     yield client
+
+
+@pytest.fixture
+def headers():
+    user_uuid = uuid4()
+    token = jwt.encode({"user_uuid": str(user_uuid)})
+    yield {"Authorization": f"Bearer {token}"}
 
 
 # store history of failures per test class name and per index in parametrize (if parametrize used)


### PR DESCRIPTION
## Context

As a backend I want to know who is requesting what so that I can GET/CREATE the right data for them

Note: even though we are using a JWT to encode the user_uuid this is Not used for Authentication, although it maybe used for this in the future with an appropriate code change (i.e. using cognito)

## Changes proposed in this pull request

* core-api: All (except /health) endpoints now require a JWT in the headers. The JWT encodes a user_uuid, which is a UUID.
* django: all requests to core-api now send a Bearer token in the header


## Guidance to review

Note that nothing is actually done with the user_uuid in this PR, this will be tackled in another ticket.

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-170


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/8925978665/job/24515954483
