### PR TITLE
Adding AWS_REGION as an empty parameter in .env.example to ensure new…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,8 @@ MINIO_PORT=9000
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin
 
+AWS_REGION=
+
 # minio or s3
 OBJECT_STORE=minio
 BUCKET_NAME=redbox-storage-dev


### PR DESCRIPTION
… repo uses can build containers locally

## Context

As a new user to the repo, `make build` shouted at me until I added an empty `AWS_REGION` parameter to my .env file. Adding this AWS_REGION parameter to the .env.example so this will be avoided for future new users of the repo setting up for the first time.

## Changes proposed in this pull request

`AWS_REGION=` added to .env.example

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
