### PR TITLE
Feature/redbox 171 add user filtering to core api

### DIFF
--- a/core_api/src/routes/file.py
+++ b/core_api/src/routes/file.py
@@ -76,10 +76,7 @@ async def add_file(file_request: FileRequest, user_uuid: Annotated[UUID, Depends
     log.info(f"publishing {file.uuid} for {file.creator_user_uuid}")
     await file_publisher.publish(file)
 
-    retrieved_file = storage_handler.read_item(file.uuid, "File")
-    log.info(f"published {retrieved_file.uuid} for {retrieved_file.creator_user_uuid}")
-
-    return retrieved_file
+    return file
 
 
 # Standard file upload endpoint for utility in quick testing

--- a/core_api/src/routes/file.py
+++ b/core_api/src/routes/file.py
@@ -119,7 +119,7 @@ def get_file(file_uuid: UUID, _user_uuid: Annotated[UUID, Depends(get_user_uuid)
 
 
 @file_app.delete("/{file_uuid}", response_model=File, tags=["file"])
-def delete_file(file_uuid: UUID, _user_uuid: Annotated[UUID, Depends(get_user_uuid)]) -> File:
+def delete_file(file_uuid: UUID, user_uuid: Annotated[UUID, Depends(get_user_uuid)]) -> File:
     """Delete a file from the object store and the database
 
     Args:
@@ -132,15 +132,15 @@ def delete_file(file_uuid: UUID, _user_uuid: Annotated[UUID, Depends(get_user_uu
     s3.delete_object(Bucket=env.bucket_name, Key=file.key)
     storage_handler.delete_item(file)
 
-    chunks = storage_handler.get_file_chunks(file.uuid)
+    chunks = storage_handler.get_file_chunks(file.uuid, user_uuid)
     storage_handler.delete_items(chunks)
     return file
 
 
 @file_app.get("/{file_uuid}/chunks", tags=["file"])
-def get_file_chunks(file_uuid: UUID) -> list[Chunk]:
+def get_file_chunks(file_uuid: UUID, user_uuid: Annotated[UUID, Depends(get_user_uuid)]) -> list[Chunk]:
     log.info(f"getting chunks for file {file_uuid}")
-    return storage_handler.get_file_chunks(file_uuid)
+    return storage_handler.get_file_chunks(file_uuid, user_uuid)
 
 
 @file_app.get("/{file_uuid}/status", tags=["file"])

--- a/core_api/tests/conftest.py
+++ b/core_api/tests/conftest.py
@@ -96,7 +96,6 @@ def chunked_file(elasticsearch_storage_handler, stored_file) -> YieldFixture[Fil
             text="hello",
             index=i,
             parent_file_uuid=stored_file.uuid,
-            metadata={},
             creator_user_uuid=stored_file.creator_user_uuid,
         )
         elasticsearch_storage_handler.write_item(chunk)

--- a/core_api/tests/conftest.py
+++ b/core_api/tests/conftest.py
@@ -96,9 +96,14 @@ def stored_file(elasticsearch_storage_handler, file) -> YieldFixture[File]:
 
 
 @pytest.fixture
-def chunked_file(elasticsearch_storage_handler, stored_file) -> YieldFixture[File]:
+def alice() -> UUID:
+    yield uuid4()
+
+
+@pytest.fixture
+def chunked_file(elasticsearch_storage_handler, stored_file, alice) -> YieldFixture[File]:
     for i in range(5):
-        chunk = Chunk(text="hello", index=i, parent_file_uuid=stored_file.uuid, metadata={})
+        chunk = Chunk(text="hello", index=i, parent_file_uuid=stored_file.uuid, metadata={}, creator_user_uuid=alice)
         elasticsearch_storage_handler.write_item(chunk)
     elasticsearch_storage_handler.refresh()
     yield stored_file

--- a/core_api/tests/conftest.py
+++ b/core_api/tests/conftest.py
@@ -7,7 +7,6 @@ from botocore.exceptions import ClientError
 from elasticsearch import Elasticsearch
 from fastapi.testclient import TestClient
 from jose import jwt
-from sentence_transformers import SentenceTransformer
 
 from core_api.src.app import app as application
 from core_api.src.app import env

--- a/core_api/tests/routes/test_file.py
+++ b/core_api/tests/routes/test_file.py
@@ -53,10 +53,11 @@ def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, chunk
     When I DELETE it to /file
     I Expect to see it removed from s3 and elastic-search, including the chunks
     """
+    user_uuid = chunked_file.creator_user_uuid
     # check assets exist
     assert s3_client.get_object(Bucket=env.bucket_name, Key=chunked_file.key)
     assert elasticsearch_storage_handler.read_item(item_uuid=chunked_file.uuid, model_type="file")
-    assert elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid)
+    assert elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid, user_uuid)
 
     response = app_client.delete(f"/file/{chunked_file.uuid}", headers=headers)
     assert response.status_code == 200
@@ -70,7 +71,7 @@ def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, chunk
     with pytest.raises(NotFoundError):
         elasticsearch_storage_handler.read_item(item_uuid=chunked_file.uuid, model_type="file")
 
-    assert not elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid)
+    assert not elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid, user_uuid)
 
 
 def test_get_file_chunks(client, chunked_file, headers):

--- a/core_api/tests/routes/test_file.py
+++ b/core_api/tests/routes/test_file.py
@@ -53,11 +53,10 @@ def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, chunk
     When I DELETE it to /file
     I Expect to see it removed from s3 and elastic-search, including the chunks
     """
-    user_uuid = chunked_file.creator_user_uuid
     # check assets exist
     assert s3_client.get_object(Bucket=env.bucket_name, Key=chunked_file.key)
     assert elasticsearch_storage_handler.read_item(item_uuid=chunked_file.uuid, model_type="file")
-    assert elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid, user_uuid)
+    assert elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid, chunked_file.creator_user_uuid)
 
     response = app_client.delete(f"/file/{chunked_file.uuid}", headers=headers)
     assert response.status_code == 200
@@ -71,7 +70,7 @@ def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, chunk
     with pytest.raises(NotFoundError):
         elasticsearch_storage_handler.read_item(item_uuid=chunked_file.uuid, model_type="file")
 
-    assert not elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid, user_uuid)
+    assert not elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid, chunked_file.creator_user_uuid)
 
 
 def test_get_file_chunks(client, chunked_file, headers):

--- a/core_api/tests/test_auth.py
+++ b/core_api/tests/test_auth.py
@@ -11,7 +11,7 @@ import pytest
         ({"Authorization": "blah blah"}, 403),
         ({"Authorization": "Bearer blah-blah"}, 401),
         ({"Authorization": "Bearer " + jwt.encode({"user_uuid": "not a uuid"}, key="super-secure-private-key")}, 401),
-        ({"Authorization": "Bearer " + jwt.encode({"user_uuid": str(uuid4())}, key="super-secure-private-key")}, 200),
+        ({"Authorization": "Bearer " + jwt.encode({"user_uuid": str(uuid4())}, key="super-secure-private-key")}, 404),
     ],
 )
 def test_get_file_fails_auth(app_client, stored_file, malformed_headers, status_code):

--- a/redbox/export/docx.py
+++ b/redbox/export/docx.py
@@ -56,7 +56,7 @@ def spotlight_complete_to_docx(
 
     document.add_heading("Summarised Files", level=1)
     for file in files:
-        document.add_paragraph(file.name, style="List Bullet")
+        document.add_paragraph(file.key, style="List Bullet")
 
     for task in spotlight_complete.tasks:
         document.add_heading(task.title, level=1)
@@ -65,11 +65,11 @@ def spotlight_complete_to_docx(
 
         raw = task.raw
         for uuid in uuid_to_file_map.keys():
-            raw = raw.replace(f"<Doc{uuid}>", f"{uuid_to_file_map[uuid].name}")
+            raw = raw.replace(f"<Doc{uuid}>", f"{uuid_to_file_map[uuid].key}")
             raw = raw.replace(f"</Doc{uuid}>", "")
 
-            raw = raw.replace(f"Doc{uuid}", f"{uuid_to_file_map[uuid].name}")
-            raw = raw.replace(f"{uuid}", f"{uuid_to_file_map[uuid].name}")
+            raw = raw.replace(f"Doc{uuid}", f"{uuid_to_file_map[uuid].key}")
+            raw = raw.replace(f"{uuid}", f"{uuid_to_file_map[uuid].key}")
 
         html_raw = markdown.markdown(task.raw)
         temp_file = tempfile.NamedTemporaryFile(delete=True, suffix=".html")

--- a/redbox/llm/spotlight/spotlight.py
+++ b/redbox/llm/spotlight/spotlight.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from redbox.llm.prompts.spotlight import (
     SPOTLIGHT_KEY_ACTIONS_TASK_PROMPT,
     SPOTLIGHT_KEY_DATES_TASK_PROMPT,
@@ -9,29 +11,33 @@ from redbox.models.spotlight import SpotlightTask
 
 # region ===== TASKS =====
 
+CREATOR_USER_UUID = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
 summary_task = SpotlightTask(
-    id="summary",
-    title="Summary",
-    prompt_template=SPOTLIGHT_SUMMARY_TASK_PROMPT,
+    id="summary", title="Summary", prompt_template=SPOTLIGHT_SUMMARY_TASK_PROMPT, creator_user_uuid=CREATOR_USER_UUID
 )
 key_dates_task = SpotlightTask(
     id="key_dates",
     title="Key Dates",
     prompt_template=SPOTLIGHT_KEY_DATES_TASK_PROMPT,
+    creator_user_uuid=CREATOR_USER_UUID,
 )
 key_actions_task = SpotlightTask(
     id="key_actions",
     title="Key Actions",
     prompt_template=SPOTLIGHT_KEY_ACTIONS_TASK_PROMPT,
+    creator_user_uuid=CREATOR_USER_UUID,
 )
 key_people_task = SpotlightTask(
     id="key_people",
     title="Key People",
     prompt_template=SPOTLIGHT_KEY_PEOPLE_TASK_PROMPT,
+    creator_user_uuid=CREATOR_USER_UUID,
 )
 key_discussion_task = SpotlightTask(
     id="key_discussion",
     title="Key Discussion",
     prompt_template=SPOTLIGHT_KEY_DISCUSSION_TASK_PROMPT,
+    creator_user_uuid=CREATOR_USER_UUID,
 )
 # endregion

--- a/redbox/models/base.py
+++ b/redbox/models/base.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Optional
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, computed_field
@@ -10,7 +9,7 @@ class PersistableModel(BaseModel):
 
     uuid: UUID = Field(default_factory=uuid4)
     created_datetime: datetime = Field(default_factory=datetime.utcnow)
-    creator_user_uuid: Optional[UUID] = None
+    creator_user_uuid: UUID
 
     @computed_field
     def model_type(self) -> str:

--- a/redbox/models/base.py
+++ b/redbox/models/base.py
@@ -1,16 +1,15 @@
 from datetime import datetime
-from typing import Annotated, Optional
 from uuid import UUID, uuid4
 
-from pydantic import AfterValidator, BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field
 
 
 class PersistableModel(BaseModel):
     """Base class for all models that can be persisted to the database."""
 
-    uuid: UUID | Annotated[str, AfterValidator(lambda x: UUID(x))] = Field(default_factory=uuid4)
+    uuid: UUID = Field(default_factory=uuid4)
     created_datetime: datetime = Field(default_factory=datetime.utcnow)
-    creator_user_uuid: Optional[UUID | Annotated[str, AfterValidator(lambda x: UUID(x))]] = None
+    creator_user_uuid: UUID = Field(default_factory=uuid4)
 
     @computed_field
     def model_type(self) -> str:

--- a/redbox/models/base.py
+++ b/redbox/models/base.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, computed_field
@@ -9,7 +10,7 @@ class PersistableModel(BaseModel):
 
     uuid: UUID = Field(default_factory=uuid4)
     created_datetime: datetime = Field(default_factory=datetime.utcnow)
-    creator_user_uuid: UUID = Field(default_factory=uuid4)
+    creator_user_uuid: Optional[UUID] = None
 
     @computed_field
     def model_type(self) -> str:

--- a/redbox/models/file.py
+++ b/redbox/models/file.py
@@ -79,7 +79,12 @@ class Metadata(BaseModel):
     # url: Optional[str] = None
 
     @classmethod
-    def merge(cls, left: Metadata, right: Metadata) -> Metadata:
+    def merge(cls, left: Optional[Metadata], right: Optional[Metadata]) -> Optional[Metadata]:
+        if not left:
+            return right
+        if not right:
+            return left
+
         def listify(obj, field_name: str) -> list:
             field_value = getattr(obj, field_name, None)
             if isinstance(field_value, list):

--- a/redbox/models/file.py
+++ b/redbox/models/file.py
@@ -110,7 +110,7 @@ class Chunk(PersistableModel):
     parent_file_uuid: UUID = Field(description="id of the original file which this text came from")
     index: int = Field(description="relative position of this chunk in the original file")
     text: str = Field(description="chunk of the original text")
-    metadata: Metadata = Field(description="subset of the unstructured Element.Metadata object")
+    metadata: Optional[Metadata] = Field(description="subset of the unstructured Element.Metadata object", default=None)
     embedding: Optional[list[float]] = Field(description="the vector representation of the text", default=None)
 
     @computed_field

--- a/redbox/parsing/chunk_clustering.py
+++ b/redbox/parsing/chunk_clustering.py
@@ -10,8 +10,8 @@ from redbox.models.file import Chunk, Metadata
 
 def cluster_chunks(
     chunks: list[Chunk],
+    embedding_model: SentenceTransformer,
     desired_chunk_size: int = 300,
-    embedding_model: SentenceTransformer = None,
     dist_weight_split: float = 0.2,
     dist_use_log: bool = True,
 ) -> list[Chunk]:
@@ -20,8 +20,8 @@ def cluster_chunks(
 
     Args:
             chunks (List[File]): List of raw (small) chunks extracted from document.
+            embedding_model (SentenceTransformer): name of the sentence embedding model used to compare chunk similarity
             desired_chunk_size (int): Avarage size of the output chunks. Defaults to 300,
-            embed_model (SentenceTransformer): name of the sentence embedding model used to compare chunk similarity
             dist_weight_split (float): Expects value between 0 and 1.
                 When calculating the combined distance metric this is the relative weight (importance)
                 of the semantic similarity vs the token counts. Defaults to .2.
@@ -72,7 +72,7 @@ def cluster_chunks(
                     parent_file_uuid=chunks_in[0].parent_file_uuid,
                     index=i,
                     text=" ".join([chunk.text for chunk in chunks_in]),
-                    metadata=reduce(Metadata.merge, [chunk.metadata for chunk in chunks_in]),
+                    metadata=reduce(Metadata.merge, [chunk.metadata for chunk in chunks_in]),  # noqa
                     creator_user_uuid=chunks_in[0].creator_user_uuid,
                 )
             out_chunks.append(new_chunk)

--- a/redbox/parsing/chunk_clustering.py
+++ b/redbox/parsing/chunk_clustering.py
@@ -127,10 +127,3 @@ def create_pdist(token_counts, pair_embed_dist, weight_embed_dist=0.2, use_log=T
     # the two above distance are combined either using sum or product (i.e. use_log=T)
     combined_dist = [x + y for x, y in zip(embed_dist, token_dist)]
     return combined_dist
-
-
-def merge_chunk_metadata(meta_in: list[Metadata]) -> Metadata:
-    """
-    Combine metadata for multiple chunks from the same document.
-    """
-    return reduce(Metadata.merge, meta_in)

--- a/redbox/parsing/chunk_clustering.py
+++ b/redbox/parsing/chunk_clustering.py
@@ -72,7 +72,7 @@ def cluster_chunks(
                     parent_file_uuid=chunks_in[0].parent_file_uuid,
                     index=i,
                     text=" ".join([chunk.text for chunk in chunks_in]),
-                    metadata=reduce(Metadata.merge, [chunk.metadata for chunk in chunks_in]),  # noqa
+                    metadata=reduce(Metadata.merge, [chunk.metadata for chunk in chunks_in]),
                     creator_user_uuid=chunks_in[0].creator_user_uuid,
                 )
             out_chunks.append(new_chunk)

--- a/redbox/parsing/chunkers.py
+++ b/redbox/parsing/chunkers.py
@@ -20,7 +20,7 @@ def other_chunker(file: File) -> list[Chunk]:
     """
     authenticated_s3_url = s3_client.generate_presigned_url(
         "get_object",
-        Params={"Bucket": env.bucket_name, "Key": file.key},
+        Params={"Bucket": file.bucket, "Key": file.key},
         ExpiresIn=3600,
     )
 

--- a/redbox/storage/elasticsearch.py
+++ b/redbox/storage/elasticsearch.py
@@ -169,29 +169,6 @@ class ElasticsearchStorageHandler(BaseStorageHandler):
         ]
         return res
 
-    def _get_embedded_child_chunks(self, parent_file_uuid: UUID) -> list[UUID]:
-        target_index = f"{self.root_index}-chunk"
-        matched_embedded_chunk_ids = [
-            UUID(x["_id"])
-            for x in scan(
-                client=self.es_client,
-                index=target_index,
-                query={
-                    "query": {
-                        "bool": {
-                            "must": [
-                                {"match": {"parent_file_uuid": str(parent_file_uuid)}},
-                                {"exists": {"field": "embedding"}},
-                            ]
-                        }
-                    }
-                },
-                _source=False,
-            )
-        ]
-
-        return matched_embedded_chunk_ids
-
     def get_file_status(self, file_uuid: UUID, user_uuid: UUID) -> FileStatus:
         """Get the status of a file and associated Chunks
 

--- a/redbox/storage/elasticsearch.py
+++ b/redbox/storage/elasticsearch.py
@@ -192,7 +192,7 @@ class ElasticsearchStorageHandler(BaseStorageHandler):
 
         return matched_embedded_chunk_ids
 
-    def get_file_status(self, file_uuid: UUID) -> FileStatus:
+    def get_file_status(self, file_uuid: UUID, user_uuid: UUID) -> FileStatus:
         """Get the status of a file and associated Chunks
 
         Args:
@@ -206,6 +206,8 @@ class ElasticsearchStorageHandler(BaseStorageHandler):
         try:
             file = self.read_item(file_uuid, "File")
         except NotFoundError:
+            raise ValueError(f"File {file_uuid} not found")
+        if file.uuid != user_uuid:
             raise ValueError(f"File {file_uuid} not found")
 
         # Test 2: Get the number of chunks for the file

--- a/redbox/storage/elasticsearch.py
+++ b/redbox/storage/elasticsearch.py
@@ -92,13 +92,13 @@ class ElasticsearchStorageHandler(BaseStorageHandler):
         )
         return result
 
-    def read_all_items(self, model_type: str) -> list[PersistableModel]:
+    def read_all_items(self, model_type: str, user_uuid: UUID) -> list[PersistableModel]:
         target_index = f"{self.root_index}-{model_type.lower()}"
         try:
             result = scan(
                 client=self.es_client,
                 index=target_index,
-                query={"query": {"match_all": {}}},
+                query={"query": {"match": {"creator_user_uuid": str(user_uuid)}}},
                 _source=True,
             )
 

--- a/redbox/storage/elasticsearch.py
+++ b/redbox/storage/elasticsearch.py
@@ -42,7 +42,7 @@ class ElasticsearchStorageHandler(BaseStorageHandler):
         )
         return resp
 
-    def write_items(self, items: list[PersistableModel]) -> list[ObjectApiResponse]:
+    def write_items(self, items: list[PersistableModel]) -> list:
         return list(map(self.write_item, items))
 
     def read_item(self, item_uuid: UUID, model_type: str):

--- a/redbox/storage/elasticsearch.py
+++ b/redbox/storage/elasticsearch.py
@@ -121,14 +121,14 @@ class ElasticsearchStorageHandler(BaseStorageHandler):
                 logging.error(e)
         return items
 
-    def list_all_items(self, model_type: str) -> list[UUID]:
+    def list_all_items(self, model_type: str, user_uuid: UUID) -> list[UUID]:
         target_index = f"{self.root_index}-{model_type.lower()}"
         try:
             # Only return _id
             results = scan(
                 client=self.es_client,
                 index=target_index,
-                query={"query": {"match_all": {}}},
+                query={"query": {"match": {"creator_user_uuid": str(user_uuid)}}},
                 _source=False,
             )
 

--- a/redbox/storage/storage_handler.py
+++ b/redbox/storage/storage_handler.py
@@ -73,3 +73,8 @@ class BaseStorageHandler(ABC):
     def read_all_items(self, model_type: str, user_uuid: UUID):
         """Read all objects of a given type from a data store"""
         pass
+
+    @abstractmethod
+    def get_file_chunks(self, parent_file_uuid: UUID, user_uuid: UUID) -> list[Chunk]:
+        """get chunks for a given file"""
+        pass

--- a/redbox/storage/storage_handler.py
+++ b/redbox/storage/storage_handler.py
@@ -35,12 +35,12 @@ class BaseStorageHandler(ABC):
         pass
 
     @abstractmethod
-    def read_item(self, item_uuid: UUID, model_type: str):
+    def read_item(self, item_uuid: UUID, model_type: str) -> PersistableModel:
         """Read an object from a data store"""
         pass
 
     @abstractmethod
-    def read_items(self, item_uuids: list[UUID], model_type: str):
+    def read_items(self, item_uuids: list[UUID], model_type: str) -> list[PersistableModel]:
         """Read a list of objects from a data store"""
         pass
 

--- a/redbox/storage/storage_handler.py
+++ b/redbox/storage/storage_handler.py
@@ -30,7 +30,7 @@ class BaseStorageHandler(ABC):
         pass
 
     @abstractmethod
-    def write_items(self, items: list):
+    def write_items(self, items: list[PersistableModel]):
         """Write a list of objects to a data store"""
         pass
 
@@ -70,6 +70,6 @@ class BaseStorageHandler(ABC):
         pass
 
     @abstractmethod
-    def read_all_items(self, model_type: str):
+    def read_all_items(self, model_type: str, user_uuid: UUID):
         """Read all objects of a given type from a data store"""
         pass

--- a/redbox/storage/storage_handler.py
+++ b/redbox/storage/storage_handler.py
@@ -35,12 +35,12 @@ class BaseStorageHandler(ABC):
         pass
 
     @abstractmethod
-    def read_item(self, item_uuid: UUID, model_type: str) -> PersistableModel:
+    def read_item(self, item_uuid: UUID, model_type: str):
         """Read an object from a data store"""
         pass
 
     @abstractmethod
-    def read_items(self, item_uuids: list[UUID], model_type: str) -> list[PersistableModel]:
+    def read_items(self, item_uuids: list[UUID], model_type: str):
         """Read a list of objects from a data store"""
         pass
 

--- a/redbox/storage/storage_handler.py
+++ b/redbox/storage/storage_handler.py
@@ -65,7 +65,7 @@ class BaseStorageHandler(ABC):
         pass
 
     @abstractmethod
-    def list_all_items(self, model_type: str):
+    def list_all_items(self, model_type: str, user_uuid: UUID):
         """List all objects of a given type from a data store"""
         pass
 

--- a/redbox/tests/conftest.py
+++ b/redbox/tests/conftest.py
@@ -14,7 +14,9 @@ T = TypeVar("T")
 YieldFixture = Generator[T, None, None]
 
 
-env = Settings()
+@pytest.fixture
+def env():
+    yield Settings(django_secret_key="", postgres_password="")
 
 
 @pytest.fixture
@@ -33,7 +35,7 @@ def claire():
 
 
 @pytest.fixture
-def file_belonging_to_alice(s3_client, file_pdf_path, alice) -> YieldFixture[File]:
+def file_belonging_to_alice(s3_client, file_pdf_path, alice, env) -> YieldFixture[File]:
     file_name = os.path.basename(file_pdf_path)
     file_type = f'.{file_name.split(".")[-1]}'
 
@@ -66,7 +68,7 @@ def chunk_belonging_to_alice(file_belonging_to_alice) -> YieldFixture[Chunk]:
 
 
 @pytest.fixture
-def file_belonging_to_bob(s3_client, file_pdf_path, bob) -> YieldFixture[File]:
+def file_belonging_to_bob(s3_client, file_pdf_path, bob, env) -> YieldFixture[File]:
     file_name = os.path.basename(file_pdf_path)
     file_type = f'.{file_name.split(".")[-1]}'
 
@@ -124,7 +126,7 @@ def file_pdf_path() -> YieldFixture[str]:
 
 
 @pytest.fixture
-def s3_client():
+def s3_client(env):
     _client = env.s3_client()
     try:
         _client.create_bucket(
@@ -155,7 +157,7 @@ def stored_chunk_belonging_to_bob(elasticsearch_storage_handler, chunk_belonging
 
 
 @pytest.fixture
-def elasticsearch_client() -> YieldFixture[Elasticsearch]:
+def elasticsearch_client(env) -> YieldFixture[Elasticsearch]:
     yield env.elasticsearch_client()
 
 

--- a/redbox/tests/conftest.py
+++ b/redbox/tests/conftest.py
@@ -18,25 +18,51 @@ env = Settings()
 
 
 @pytest.fixture
-def chunk() -> Chunk:
-    test_chunk = Chunk(
-        parent_file_uuid=uuid4(),
-        index=1,
-        text="test_text",
-        metadata={},
-    )
-    return test_chunk
+def alice():
+    yield uuid4()
 
 
 @pytest.fixture
-def another_chunk() -> Chunk:
-    test_chunk = Chunk(
+def bob():
+    yield uuid4()
+
+
+@pytest.fixture
+def claire():
+    yield uuid4()
+
+
+@pytest.fixture
+def chunk_belonging_to_alice(alice) -> Chunk:
+    chunk = Chunk(
+        creator_user_uuid=alice,
         parent_file_uuid=uuid4(),
         index=1,
-        text="test_text",
-        metadata={},
+        text="hello, i am Alice!",
     )
-    return test_chunk
+    return chunk
+
+
+@pytest.fixture
+def chunk_belonging_to_bob(bob) -> Chunk:
+    chunk = Chunk(
+        creator_user_uuid=bob,
+        parent_file_uuid=uuid4(),
+        index=1,
+        text="hello, i am Bob!",
+    )
+    return chunk
+
+
+@pytest.fixture
+def chunk_belonging_to_claire(claire) -> Chunk:
+    chunk = Chunk(
+        creator_user_uuid=claire,
+        parent_file_uuid=uuid4(),
+        index=1,
+        text="hello, i am Claire!",
+    )
+    return chunk
 
 
 @pytest.fixture
@@ -87,9 +113,17 @@ def file(s3_client, file_pdf_path) -> YieldFixture[File]:
 
 
 @pytest.fixture
-def stored_chunk(elasticsearch_storage_handler, chunk) -> Chunk:
-    elasticsearch_storage_handler.write_item(item=chunk)
-    return chunk
+def stored_chunk_belonging_to_alice(elasticsearch_storage_handler, chunk_belonging_to_alice, alice) -> Chunk:
+    elasticsearch_storage_handler.write_item(item=chunk_belonging_to_alice)
+    elasticsearch_storage_handler.refresh()
+    yield chunk_belonging_to_alice
+
+
+@pytest.fixture
+def stored_chunk_belonging_to_bob(elasticsearch_storage_handler, chunk_belonging_to_bob) -> Chunk:
+    elasticsearch_storage_handler.write_item(item=chunk_belonging_to_bob)
+    elasticsearch_storage_handler.refresh()
+    yield chunk_belonging_to_bob
 
 
 @pytest.fixture

--- a/redbox/tests/conftest.py
+++ b/redbox/tests/conftest.py
@@ -55,14 +55,14 @@ def file_belonging_to_alice(s3_client, file_pdf_path, alice) -> YieldFixture[Fil
 
 
 @pytest.fixture
-def chunk_belonging_to_alice(file_belonging_to_alice) -> Chunk:
+def chunk_belonging_to_alice(file_belonging_to_alice) -> YieldFixture[Chunk]:
     chunk = Chunk(
         creator_user_uuid=file_belonging_to_alice.creator_user_uuid,
         parent_file_uuid=file_belonging_to_alice.uuid,
         index=1,
         text="hello, i am Alice!",
     )
-    return chunk
+    yield chunk
 
 
 @pytest.fixture
@@ -88,25 +88,25 @@ def file_belonging_to_bob(s3_client, file_pdf_path, bob) -> YieldFixture[File]:
 
 
 @pytest.fixture
-def chunk_belonging_to_bob(file_belonging_to_bob) -> Chunk:
+def chunk_belonging_to_bob(file_belonging_to_bob) -> YieldFixture[Chunk]:
     chunk = Chunk(
         creator_user_uuid=file_belonging_to_bob.creator_user_uuid,
         parent_file_uuid=file_belonging_to_bob.uuid,
         index=1,
         text="hello, i am Bob!",
     )
-    return chunk
+    yield chunk
 
 
 @pytest.fixture
-def chunk_belonging_to_claire(claire) -> Chunk:
+def chunk_belonging_to_claire(claire) -> YieldFixture[Chunk]:
     chunk = Chunk(
         creator_user_uuid=claire,
         parent_file_uuid=uuid4(),
         index=1,
         text="hello, i am Claire!",
     )
-    return chunk
+    yield chunk
 
 
 @pytest.fixture
@@ -139,14 +139,16 @@ def s3_client():
 
 
 @pytest.fixture
-def stored_chunk_belonging_to_alice(elasticsearch_storage_handler, chunk_belonging_to_alice, alice) -> Chunk:
+def stored_chunk_belonging_to_alice(
+    elasticsearch_storage_handler, chunk_belonging_to_alice, alice
+) -> YieldFixture[Chunk]:
     elasticsearch_storage_handler.write_item(item=chunk_belonging_to_alice)
     elasticsearch_storage_handler.refresh()
     yield chunk_belonging_to_alice
 
 
 @pytest.fixture
-def stored_chunk_belonging_to_bob(elasticsearch_storage_handler, chunk_belonging_to_bob) -> Chunk:
+def stored_chunk_belonging_to_bob(elasticsearch_storage_handler, chunk_belonging_to_bob) -> YieldFixture[Chunk]:
     elasticsearch_storage_handler.write_item(item=chunk_belonging_to_bob)
     elasticsearch_storage_handler.refresh()
     yield chunk_belonging_to_bob
@@ -158,5 +160,5 @@ def elasticsearch_client() -> YieldFixture[Elasticsearch]:
 
 
 @pytest.fixture
-def elasticsearch_storage_handler(elasticsearch_client):
+def elasticsearch_storage_handler(elasticsearch_client) -> YieldFixture[ElasticsearchStorageHandler]:
     yield ElasticsearchStorageHandler(es_client=elasticsearch_client, root_index="redbox-test-data")

--- a/redbox/tests/parsing/test_file_chunker.py
+++ b/redbox/tests/parsing/test_file_chunker.py
@@ -8,8 +8,8 @@ env = Settings()
 
 
 @pytest.mark.parametrize("chunk_clustering, expected_chunk_number", [(False, 54), (True, 13)])
-def test_chunk_file(file, chunk_clustering, expected_chunk_number):
+def test_chunk_file(file_belonging_to_alice, chunk_clustering, expected_chunk_number):
     embedding_model = SentenceTransformerDB(env.embedding_model)
     file_chunker = FileChunker(embedding_model)
-    chunks = file_chunker.chunk_file(file, chunk_clustering)
+    chunks = file_chunker.chunk_file(file_belonging_to_alice, chunk_clustering)
     assert len(chunks) == expected_chunk_number

--- a/redbox/tests/parsing/test_file_chunker.py
+++ b/redbox/tests/parsing/test_file_chunker.py
@@ -1,14 +1,11 @@
 import pytest
 
 from redbox.model_db import SentenceTransformerDB
-from redbox.models import Settings
 from redbox.parsing.file_chunker import FileChunker
-
-env = Settings()
 
 
 @pytest.mark.parametrize("chunk_clustering, expected_chunk_number", [(False, 54), (True, 13)])
-def test_chunk_file(file_belonging_to_alice, chunk_clustering, expected_chunk_number):
+def test_chunk_file(file_belonging_to_alice, env, chunk_clustering, expected_chunk_number):
     embedding_model = SentenceTransformerDB(env.embedding_model)
     file_chunker = FileChunker(embedding_model)
     chunks = file_chunker.chunk_file(file_belonging_to_alice, chunk_clustering)

--- a/redbox/tests/storage/test_elasticsearch.py
+++ b/redbox/tests/storage/test_elasticsearch.py
@@ -121,11 +121,31 @@ def test_list_all_items(
     * a saved chunk belonging to Alice
     * a saved chunk belonging to Bob
     * an unsaved chunk belonging to Claire
-    When I call list_all_items as alice on their common type-name
+    When I call list_all_items as alice
     Then I expect to see the uuids of the saved objects that belong to alice returned
     """
     uuids = elasticsearch_storage_handler.list_all_items("Chunk", alice)
     assert len(uuids) == 1
+
+
+def test_read_all_items(
+    elasticsearch_storage_handler: ElasticsearchStorageHandler,
+    stored_chunk_belonging_to_alice: Chunk,
+    stored_chunk_belonging_to_bob: Chunk,
+    chunk_belonging_to_claire: Chunk,
+    alice: UUID,
+):
+    """
+    Given that I have
+    * a saved chunk belonging to Alice
+    * a saved chunk belonging to Bob
+    * an unsaved chunk belonging to Claire
+    When I call read_all_items as alice
+    Then I expect to see the one Chunk belonging to alice
+    """
+    chunks = elasticsearch_storage_handler.read_all_items("Chunk", alice)
+    assert len(chunks) == 1
+    assert chunks[0].creator_user_uuid == alice
 
 
 def test_elastic_delete_item(elasticsearch_storage_handler, stored_chunk_belonging_to_alice):

--- a/redbox/tests/storage/test_elasticsearch.py
+++ b/redbox/tests/storage/test_elasticsearch.py
@@ -169,6 +169,8 @@ def test_get_file_chunks(
     When I call get_file_chunks with the right file id and alice's id
     I Expect the single chunk to be retrieved
     """
+    assert stored_chunk_belonging_to_alice.creator_user_uuid
+
     chunks = elasticsearch_storage_handler.get_file_chunks(
         stored_chunk_belonging_to_alice.parent_file_uuid,
         stored_chunk_belonging_to_alice.creator_user_uuid,

--- a/redbox/tests/storage/test_elasticsearch.py
+++ b/redbox/tests/storage/test_elasticsearch.py
@@ -1,4 +1,4 @@
-from uuid import uuid4
+from uuid import uuid4, UUID
 
 import pytest
 from elasticsearch import NotFoundError
@@ -25,35 +25,35 @@ def test_elasticsearch_client_connection(elasticsearch_client):
     assert isinstance(test_elasticsearch_storage_handler.model_type_map, dict)
 
 
-def test_elasticsearch_write_read_item(elasticsearch_storage_handler, chunk):
+def test_elasticsearch_write_read_item(elasticsearch_storage_handler, chunk_belonging_to_alice):
     """
     Given that `Chunk` is a valid model
     When I
     Then I expect a valid Chunk to be returned on read"
     """
     # Write the chunk
-    elasticsearch_storage_handler.write_item(item=chunk)
+    elasticsearch_storage_handler.write_item(item=chunk_belonging_to_alice)
 
     # Read the chunk
-    chunk_read = elasticsearch_storage_handler.read_item(chunk.uuid, "Chunk")
+    chunk_read = elasticsearch_storage_handler.read_item(chunk_belonging_to_alice.uuid, "Chunk")
 
-    assert chunk_read.uuid == chunk.uuid
+    assert chunk_read.uuid == chunk_belonging_to_alice.uuid
 
 
-def test_elastic_read_item(elasticsearch_storage_handler, stored_chunk):
-    read_chunk = elasticsearch_storage_handler.read_item(stored_chunk.uuid, "Chunk")
-    assert read_chunk.uuid == stored_chunk.uuid
-    assert read_chunk.parent_file_uuid == stored_chunk.parent_file_uuid
-    assert read_chunk.index == stored_chunk.index
-    assert read_chunk.text == stored_chunk.text
-    assert read_chunk.metadata == stored_chunk.metadata
-    assert read_chunk.creator_user_uuid == stored_chunk.creator_user_uuid
-    assert read_chunk.token_count == stored_chunk.token_count
+def test_elastic_read_item(elasticsearch_storage_handler, stored_chunk_belonging_to_alice):
+    read_chunk = elasticsearch_storage_handler.read_item(stored_chunk_belonging_to_alice.uuid, "Chunk")
+    assert read_chunk.uuid == stored_chunk_belonging_to_alice.uuid
+    assert read_chunk.parent_file_uuid == stored_chunk_belonging_to_alice.parent_file_uuid
+    assert read_chunk.index == stored_chunk_belonging_to_alice.index
+    assert read_chunk.text == stored_chunk_belonging_to_alice.text
+    assert read_chunk.metadata == stored_chunk_belonging_to_alice.metadata
+    assert read_chunk.creator_user_uuid == stored_chunk_belonging_to_alice.creator_user_uuid
+    assert read_chunk.token_count == stored_chunk_belonging_to_alice.token_count
 
 
 def test_elastic_delete_item_fail(
     elasticsearch_storage_handler: ElasticsearchStorageHandler,
-    another_chunk,
+    chunk_belonging_to_bob,
 ):
     """
     Given that I have an non-existent item uuid
@@ -61,7 +61,7 @@ def test_elastic_delete_item_fail(
     Then I expect to see a NotFoundError error raised
     """
     with pytest.raises(NotFoundError):
-        elasticsearch_storage_handler.delete_item(another_chunk)
+        elasticsearch_storage_handler.delete_item(chunk_belonging_to_bob)
 
 
 def test_elastic_read_item_fail(
@@ -82,8 +82,10 @@ def test_elastic_write_read_delete_items(elasticsearch_storage_handler):
     When I call write_items on them
     Then I expect to see them written to the database
     """
+    creator_user_uuid = uuid4()
     chunks = [
         Chunk(
+            creator_user_uuid=creator_user_uuid,
             parent_file_uuid=uuid4(),
             index=i,
             text="test_text",
@@ -102,29 +104,37 @@ def test_elastic_write_read_delete_items(elasticsearch_storage_handler):
     elasticsearch_storage_handler.delete_items(chunks)
 
     # Check that the chunks are deleted
-    items_left = elasticsearch_storage_handler.list_all_items("Chunk")
+    items_left = elasticsearch_storage_handler.list_all_items("Chunk", creator_user_uuid)
 
     assert all(chunk.uuid not in items_left for chunk in chunks)
 
 
-@pytest.mark.xfail(reason="")
-def test_list_all_items(elasticsearch_storage_handler: ElasticsearchStorageHandler, chunk: Chunk):
+def test_list_all_items(
+    elasticsearch_storage_handler: ElasticsearchStorageHandler,
+    stored_chunk_belonging_to_alice: Chunk,
+    stored_chunk_belonging_to_bob: Chunk,
+    chunk_belonging_to_claire: Chunk,
+    alice: UUID,
+):
     """
-    Given that I have both saved and unsaved objects of the same type
-    When I call list_all_items on their common type-name
-    Then I expect to see the uuids of the saved objects returned
+    Given that I have
+    * a saved chunk belonging to Alice
+    * a saved chunk belonging to Bob
+    * an unsaved chunk belonging to Claire
+    When I call list_all_items as alice on their common type-name
+    Then I expect to see the uuids of the saved objects that belong to alice returned
     """
-    uuids = elasticsearch_storage_handler.list_all_items("Chunk")
-    assert len(uuids) > 0
+    uuids = elasticsearch_storage_handler.list_all_items("Chunk", alice)
+    assert len(uuids) == 1
 
 
-def test_elastic_delete_item(elasticsearch_storage_handler, stored_chunk):
+def test_elastic_delete_item(elasticsearch_storage_handler, stored_chunk_belonging_to_alice):
     """
     Given that I have a saved object
     When I call delete_item on it
     Then I expect to not be able to read the item
     """
-    elasticsearch_storage_handler.delete_item(stored_chunk)
+    elasticsearch_storage_handler.delete_item(stored_chunk_belonging_to_alice)
 
     with pytest.raises(NotFoundError):
-        elasticsearch_storage_handler.read_item(stored_chunk.uuid, "Chunk")
+        elasticsearch_storage_handler.read_item(stored_chunk_belonging_to_alice.uuid, "Chunk")

--- a/redbox/tests/storage/test_elasticsearch.py
+++ b/redbox/tests/storage/test_elasticsearch.py
@@ -158,3 +158,36 @@ def test_elastic_delete_item(elasticsearch_storage_handler, stored_chunk_belongi
 
     with pytest.raises(NotFoundError):
         elasticsearch_storage_handler.read_item(stored_chunk_belonging_to_alice.uuid, "Chunk")
+
+
+def test_get_file_chunks(
+    elasticsearch_storage_handler: ElasticsearchStorageHandler,
+    stored_chunk_belonging_to_alice: Chunk,
+):
+    """
+    Given that a chunk belonging to a file belonging alice have been saved
+    When I call get_file_chunks with the right file id and alice's id
+    I Expect the single chunk to be retrieved
+    """
+    chunks = elasticsearch_storage_handler.get_file_chunks(
+        stored_chunk_belonging_to_alice.parent_file_uuid,
+        stored_chunk_belonging_to_alice.creator_user_uuid,
+    )
+
+    assert len(chunks) == 1
+
+
+def test_get_file_chunks_fail(
+    elasticsearch_storage_handler: ElasticsearchStorageHandler,
+    stored_chunk_belonging_to_alice: Chunk,
+):
+    """
+    Given that a chunk belonging to a file belonging alice have been saved
+    When I call get_file_chunks with the right file id and another id
+    I Expect the no chunks to be retrieved
+    """
+    other_chunks = elasticsearch_storage_handler.get_file_chunks(
+        stored_chunk_belonging_to_alice.parent_file_uuid,
+        uuid4(),
+    )
+    assert not other_chunks

--- a/redbox/tests/storage/test_elasticsearch.py
+++ b/redbox/tests/storage/test_elasticsearch.py
@@ -89,7 +89,6 @@ def test_elastic_write_read_delete_items(elasticsearch_storage_handler):
             parent_file_uuid=uuid4(),
             index=i,
             text="test_text",
-            metadata={},
         )
         for i in range(10)
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import os
-from uuid import uuid4
 
 import boto3
 import pytest
@@ -41,8 +40,8 @@ def s3_client():
 
 @pytest.fixture
 def headers():
-    user_uuid = uuid4()
-    token = jwt.encode({"user_uuid": str(user_uuid)}, key="super-secure-private-key")
+    static_user_uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    token = jwt.encode({"user_uuid": static_user_uuid}, key="super-secure-private-key")
     yield {"Authorization": f"Bearer {token}"}
 
 

--- a/worker/tests/conftest.py
+++ b/worker/tests/conftest.py
@@ -95,7 +95,6 @@ def chunk() -> YieldFixture[Chunk]:
         parent_file_uuid=uuid4(),
         index=1,
         text="test_text",
-        metadata={},
     )
     yield test_chunk
 

--- a/worker/tests/conftest.py
+++ b/worker/tests/conftest.py
@@ -91,11 +91,7 @@ def elasticsearch_storage_handler(
 
 @pytest.fixture
 def chunk() -> YieldFixture[Chunk]:
-    test_chunk = Chunk(
-        parent_file_uuid=uuid4(),
-        index=1,
-        text="test_text",
-    )
+    test_chunk = Chunk(parent_file_uuid=uuid4(), index=1, text="test_text", creator_user_uuid=uuid4())
     yield test_chunk
 
 

--- a/worker/tests/conftest.py
+++ b/worker/tests/conftest.py
@@ -69,10 +69,7 @@ def file(s3_client, file_pdf_path):
             Tagging=f"file_type={file_type}",
         )
 
-    file_record = File(
-        key=file_name,
-        bucket=env.bucket_name,
-    )
+    file_record = File(key=file_name, bucket=env.bucket_name, creator_user_uuid=uuid4())
 
     yield file_record
 

--- a/worker/tests/test_app.py
+++ b/worker/tests/test_app.py
@@ -2,11 +2,8 @@ import pytest
 from faststream.redis import TestRedisBroker
 
 
-from worker.src.app import router
-from redbox.models import Settings
+from worker.src.app import router, env
 from redbox.storage import ElasticsearchStorageHandler
-
-env = Settings()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Context

As a User I only want to be able to GET & DELETE my own files, and no one else should be able to access them

## Changes proposed in this pull request

* I have added `user_uuid` to various storage methods that search for data to ensure that it only returns data belonging to the relevant user
* In `core_api/src/routes/file.py` I have ensured that we are now using the `user_uuid` to check that the user can only access their own data
* I *have not* tackled the important issue of how to ensure that the `/chat/rag` endpoint filters data belonging to the user because:
  1. I wasn't sure how to
  2. I think that there maybe some change to this endpoint anyway to allow for streaming 
  3. This PR is big enough

## Guidance to review

All fairly dull stuff tbh. I have added a lot of tests, they should pass 🤞 

## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-171

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/8967112884
