### PR TITLE
bugfix/restored model download

### DIFF
--- a/core_api/Dockerfile
+++ b/core_api/Dockerfile
@@ -11,6 +11,7 @@ ENV POETRY_NO_INTERACTION=1 \
 # Add redbox python package and install it with poetry
 ADD redbox/ /app/redbox
 ADD pyproject.toml poetry.lock /app/
+ADD download_embedder.py /app/
 ADD redbox/ /app/redbox
 
 RUN --mount=type=cache,target=$POETRY_CACHE_DIR poetry install --no-root --no-ansi --with api,ai --without worker,dev
@@ -26,6 +27,10 @@ COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 COPY core_api/ /app/core_api/
 ADD redbox/ /app/redbox
+ADD download_embedder.py /app/
+
+# Download the model
+RUN type=cache python download_embedder.py --embedding_model ${EMBEDDING_MODEL}
 
 # Run FastAPI
 EXPOSE 5002

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -156,10 +156,9 @@ def remove_doc_view(request, doc_id: str):
 
 @login_required
 def sessions_view(request, session_id: str = ""):
-    
     USE_STREAMING = False
     STREAMING_ENDPOINT = "ws://localhost:8888"
-    
+
     chat_history = ChatHistory.objects.all().filter(users=request.user)
 
     messages = []
@@ -170,10 +169,7 @@ def sessions_view(request, session_id: str = ""):
         "session_id": session_id,
         "messages": messages,
         "chat_history": chat_history,
-        "streaming": {
-            "in_use": USE_STREAMING,
-            "endpoint": STREAMING_ENDPOINT
-        }
+        "streaming": {"in_use": USE_STREAMING, "endpoint": STREAMING_ENDPOINT},
     }
 
     return render(


### PR DESCRIPTION
## Context

I removed the mode-download stage in error in https://github.com/i-dot-ai/redbox-copilot/pull/300 

## Changes proposed in this pull request

The model download stage has been restored

## Guidance to review

do it build?

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
