### PR TITLE
Make logging show up from Django app running in container.

### DIFF
--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -236,24 +236,26 @@ DATABASES = {
     }
 }
 
+LOG_LEVEL = "DEBUG"
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {"verbose": {"format": "%(asctime)s %(levelname)s %(module)s: %(message)s"}},
     "handlers": {
         "file": {
-            "level": "DEBUG",
+            "level": LOG_LEVEL,
             "class": "logging.FileHandler",
             "filename": os.path.join(LOG_ROOT, "application.log"),
             "formatter": "verbose",
         },
         "console": {
-            "level": "DEBUG",
+            "level": LOG_LEVEL,
             "class": "logging.StreamHandler",
             "formatter": "verbose",
         },
     },
-    "loggers": {"application": {"handlers": [LOG_HANDLER], "level": "DEBUG", "propagate": True}},
+    "root": {"handlers": ["console"], "level": LOG_LEVEL},
+    "loggers": {"application": {"handlers": [LOG_HANDLER], "level": LOG_LEVEL, "propagate": True}},
 }
 
 # link to core_api app


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
