### PR TITLE
Fix button alignment on Documents page

### DIFF
--- a/django_app/redbox_app/templates/documents.html
+++ b/django_app/redbox_app/templates/documents.html
@@ -49,11 +49,12 @@
       {% endfor %}
     </tbody>
   </table>
-</div>
 
-{{ govukButton(
-  text="Upload a new document",
-  href="/upload"
-) }}
+  {{ govukButton(
+    text="Upload a new document",
+    href="/upload"
+  ) }}
+
+</div>
 
 {% endblock %}


### PR DESCRIPTION
## Context

Fixing the button alignment on the Documents page

## Guidance to review

Go to Documents page. The "Upload a new document" button should now be aligned like this:

![image](https://github.com/i-dot-ai/redbox-copilot/assets/1634605/34258407-a598-4ae3-ac90-bab5ab9c0117)
