### PR TITLE
Redirect to documents page on sucessful file upload

### DIFF
--- a/django_app/redbox_app/redbox_core/client.py
+++ b/django_app/redbox_app/redbox_core/client.py
@@ -13,7 +13,7 @@ def s3_client():
             aws_secret_access_key=settings.AWS_S3_SECRET_ACCESS_KEY,
             region_name=settings.AWS_S3_REGION_NAME,
         )
-    elif settings.OBJECT_STORE == "minio":
+    else:
         client = boto3.client(
             "s3",
             aws_access_key_id=settings.AWS_ACCESS_KEY_ID,

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -115,6 +115,10 @@ def upload_view(request):
             except ValueError as value_error:
                 errors.append(value_error.args[0])
 
+            if not errors:
+                return redirect(documents_view)
+
+
     return render(
         request,
         template_name="upload.html",

--- a/django_app/redbox_app/templates/remove-doc.html
+++ b/django_app/redbox_app/templates/remove-doc.html
@@ -5,7 +5,6 @@
 
 {% block content %}
 
-<a href="{{url('documents')}}" class="govuk-back-link">Back</a>
 <form method="post" enctype="multipart/form-data">
 
 <div class="govuk-width-container">

--- a/django_app/redbox_app/templates/upload.html
+++ b/django_app/redbox_app/templates/upload.html
@@ -5,29 +5,11 @@
 
 {% block content %}
 
-<a href="{{url('documents')}}" class="govuk-back-link">Back</a>
-<form method="post" enctype="multipart/form-data">
-
 <div class="govuk-width-container">
+
   <form method="post" enctype="multipart/form-data">
 
     <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
-
-    {% if uploaded %}
-    <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="upload-success" data-module="govuk-notification-banner">
-      <div class="govuk-notification-banner__header">
-        <h2 class="govuk-notification-banner__title" id="upload-success">
-          Success
-        </h2>
-      </div>
-      <div class="govuk-notification-banner__content">
-        <!-- TODO: add copy to outline next stages for ingestion etc. -->
-        <h3 class="govuk-notification-banner__heading">
-          Your file has been uploaded
-        </h3>
-      </div>
-    </div>
-    {% endif %}
 
     <div class="govuk-form-group {% if errors.upload_doc %} govuk-form-group--error{% endif %}">
       <label class="govuk-label" for="upload-doc">

--- a/django_app/tests/test_views.py
+++ b/django_app/tests/test_views.py
@@ -32,9 +32,8 @@ def test_upload_view(alice, client, file_pdf_path, s3_client):
     with open(file_pdf_path, "rb") as f:
         response = client.post("/upload/", {"uploadDoc": f})
 
-        assert response.status_code == 200
-        assert "Your file has been uploaded" in str(response.content)
-
+        assert response.status_code == 302
+        assert response.url == "/documents/"
         assert count_s3_objects(s3_client) == previous_count + 1
 
 


### PR DESCRIPTION
## Context

Currently, on successful file upload, it directs back to the document upload page. This then causes problems with the success message appearing when it shouldn't

## Changes proposed in this pull request

* Redirect to documents page on successful file upload
* Remove back links (these weren't in the correct containers, but they're not needed as there are cancel buttons)

## Guidance to review

* Check a successful file upload
* Check uploading an unsupported file still stays on the same page and shows the error
