### PR TITLE
bugfix/REDBOX-239-error-on-sign-in-if-already-signed-in

### DIFF
--- a/django_app/redbox_app/templates/homepage.html
+++ b/django_app/redbox_app/templates/homepage.html
@@ -9,7 +9,9 @@
             <div class="govuk-grid-column-two-thirds">
                 <h1 class="govuk-heading-xl">Ask any question of documents in your Redbox</h1>
                 <p class="govuk-body-l">Use Artificial Intelligence (AI) to get insights from your personal document set. You can use up to, and including, Official Sensitive documents.</p>
+                {% if not request.user.is_authenticated %}
                 <p class="govuk-body">If you have an account, please <a class="govuk-link" href="{{url('sign-in')}}">sign in</a> to get started</p>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Context

As a User I do not want to see the sign in link if i am already signed in so that i dont get confused 

## Changes proposed in this pull request

sign in link no longer available for users that are signed in

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
