### PR TITLE
Bugfix/sort out urls

### DIFF
--- a/django_app/redbox_app/redbox_core/auth_views.py
+++ b/django_app/redbox_app/redbox_core/auth_views.py
@@ -11,13 +11,15 @@ logger = logging.getLogger(__name__)
 
 
 def sign_in_view(request: HttpRequest):
+    if request.user.is_authenticated:
+        return redirect("homepage")
     if request.method == "POST":
         form = SignInForm(request.POST)
         if form.is_valid():
             email = form.cleaned_data["email"].lower()
             try:
                 user = models.User.objects.get(email=email)
-                link = MagicLink.objects.create(user=user, redirect_to="/sessions")
+                link = MagicLink.objects.create(user=user, redirect_to="/")
                 full_link = request.build_absolute_uri(link.get_absolute_url())
 
                 # Email link to user
@@ -43,6 +45,8 @@ def sign_in_view(request: HttpRequest):
 
 
 def sign_in_link_sent_view(request: HttpRequest):
+    if request.user.is_authenticated:
+        return redirect("homepage")
     return render(
         request,
         template_name="sign-in-link-sent.html",
@@ -52,8 +56,4 @@ def sign_in_link_sent_view(request: HttpRequest):
 
 def signed_out_view(request: HttpRequest):
     logout(request)
-    return render(
-        request,
-        template_name="signed-out.html",
-        context={"request": request},
-    )
+    return redirect("homepage")

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import uuid
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
@@ -7,6 +8,8 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.views.decorators.http import require_http_methods
+from yarl import URL
+
 from redbox_app.redbox_core.client import CoreApiClient
 from redbox_app.redbox_core.models import (
     ChatHistory,
@@ -15,7 +18,6 @@ from redbox_app.redbox_core.models import (
     File,
     ProcessingStatusEnum,
 )
-from yarl import URL
 
 logger = logging.getLogger(__name__)
 logger.setLevel("DEBUG")
@@ -127,7 +129,7 @@ def upload_view(request):
 
 
 @login_required
-def remove_doc_view(request, doc_id: str):
+def remove_doc_view(request, doc_id: uuid):
     file = File.objects.get(pk=doc_id)
     if request.method == "POST":
         logger.info("Removing document: %s", request.POST["doc_id"])
@@ -141,7 +143,7 @@ def remove_doc_view(request, doc_id: str):
 
 
 @login_required
-def sessions_view(request: HttpRequest, session_id: str = ""):
+def sessions_view(request: HttpRequest, session_id: uuid = None):
     chat_history = ChatHistory.objects.all().filter(users=request.user)
 
     messages = []

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -8,8 +8,6 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.views.decorators.http import require_http_methods
-from yarl import URL
-
 from redbox_app.redbox_core.client import CoreApiClient
 from redbox_app.redbox_core.models import (
     ChatHistory,
@@ -18,6 +16,7 @@ from redbox_app.redbox_core.models import (
     File,
     ProcessingStatusEnum,
 )
+from yarl import URL
 
 logger = logging.getLogger(__name__)
 logger.setLevel("DEBUG")

--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -48,7 +48,7 @@
         </a>
       </div>
       <div class="govuk-header__content">
-        <a href="/" class="govuk-header__link govuk-header__service-name">
+        <a href="{{url('homepage')}}" class="govuk-header__link govuk-header__service-name">
           Redbox Copilot
         </a>
         <nav aria-label="Menu" class="govuk-header__navigation">

--- a/django_app/redbox_app/templates/documents.html
+++ b/django_app/redbox_app/templates/documents.html
@@ -40,13 +40,13 @@
           <td class="govuk-table__cell">
             {{ govukButton(
               text="Download" + "<span class=\"govuk-visually-hidden\">" + file.name + "</span>",
-              href=file.path,
+              href=file.url,
               classes="govuk-button--secondary govuk-!-margin-bottom-0",
               download=True
             ) }}
             {{ govukButton(
               text="Remove" + "<span class=\"govuk-visually-hidden\">" + file.name + "</span>",
-              href="/remove-doc/" + file.id | string,
+              href=url('remove-doc', file.id),
               classes="govuk-button--warning govuk-!-margin-bottom-0"
             ) }}
           </td>
@@ -57,7 +57,7 @@
 
   {{ govukButton(
     text="Upload a new document",
-    href="/upload"
+    href=url('upload')
   ) }}
 
 </div>

--- a/django_app/redbox_app/templates/remove-doc.html
+++ b/django_app/redbox_app/templates/remove-doc.html
@@ -28,7 +28,7 @@
 
     <div class="govuk-button-group">
       {{ govukButton(text="Remove", classes="govuk-button--warning") }}
-      {{ govukButton(text="Cancel", classes="govuk-button--secondary", href="/documents") }}
+      {{ govukButton(text="Cancel", classes="govuk-button--secondary", href=url('documents')) }}
     </div>
 
   </form>

--- a/django_app/redbox_app/templates/sessions.html
+++ b/django_app/redbox_app/templates/sessions.html
@@ -11,7 +11,7 @@
 
     {{ govukButton(
       text="Start a new session",
-      href="/sessions",
+      href=url('sessions'),
       classes="govuk-button--secondary"
     ) }}
 
@@ -19,11 +19,11 @@
     <ul class="govuk-list govuk-list--spaced">
       {% for session in chat_history %}
         <li>
-          <a class="govuk-link" href="/sessions/{{ session.id }}">{{ session.name }}</a>
+          <a class="govuk-link" href="{{url('sessions', session.id)}}">{{ session.name }}</a>
         </li>
       {% endfor %}
     </ul>
-      
+
   </div>
 
   <chat-controller data-stream-url="{{ streaming.endpoint }}" data-session-id="{{ session_id }}" class="govuk-grid-column-two-thirds">

--- a/django_app/redbox_app/templates/upload.html
+++ b/django_app/redbox_app/templates/upload.html
@@ -14,7 +14,7 @@
     <div class="govuk-form-group {% if errors.upload_doc %} govuk-form-group--error{% endif %}">
       <label class="govuk-label" for="upload-doc">
         <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
-      </label>    
+      </label>
       <p class="govuk-body iai-file-types" id="upload-doc-filetypes">Limit 200MB per file: EML, HTML, JSON, MD, MSG, RST, RTF, TXT, XML, CSV, DOC, DOCX, EPUB, ODT, PDF, PPT, PPTX, TSV, XLSX, HTM</p>
       {% for error in errors.upload_doc %}
         <p id="file-upload-doc-error" class="govuk-error-message">
@@ -27,7 +27,7 @@
 
     <div class="govuk-button-group">
       {{ govukButton(text="Upload") }}
-      {{ govukButton(text="Cancel", classes="govuk-button--secondary", href="/documents") }}
+      {{ govukButton(text="Cancel", classes="govuk-button--secondary", href=url('documents')) }}
     </div>
 
   </form>

--- a/django_app/redbox_app/urls.py
+++ b/django_app/redbox_app/urls.py
@@ -27,20 +27,31 @@ info_urlpatterns = [
     path("support/", info_views.support_view, name="support"),
 ]
 
-other_urlpatterns = [
-    path("", views.homepage_view, name="homepage"),
-    path("admin/", admin.site.urls),
-    path("accounts/", include("allauth.urls")),
+file_urlpatterns = [
     path("documents/", views.documents_view, name="documents"),
     path("upload/", views.upload_view, name="upload"),
-    path("remove-doc/<str:doc_id>", views.remove_doc_view, name="remove_doc"),
-    path("sessions/<str:session_id>/", views.sessions_view, name="sessions"),
+    path("remove-doc/<uuid:doc_id>", views.remove_doc_view, name="remove-doc"),
+]
+
+chat_urlpatterns = [
+    path("sessions/<uuid:session_id>/", views.sessions_view, name="sessions"),
     path("sessions/", views.sessions_view, name="sessions"),
-    path("post-message/", views.post_message, name="post_message"),
+    path("post-message/", views.post_message, name="post-message"),
+]
+
+admin_urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("accounts/", include("allauth.urls")),
+]
+
+other_urlpatterns = [
+    path("", views.homepage_view, name="homepage"),
     path("health/", views.health, name="health"),
 ]
 
-urlpatterns = info_urlpatterns + other_urlpatterns + auth_urlpatterns
+urlpatterns = (
+    info_urlpatterns + other_urlpatterns + auth_urlpatterns + chat_urlpatterns + file_urlpatterns + admin_urlpatterns
+)
 
 if settings.DEBUG:
     urlpatterns = urlpatterns + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
## Context

URL's in templates and generally the flow is a bit borked

## Changes proposed in this pull request

- Used jinja2 url pipe throughout the templates
- Added check for a logged-in user trying to get to logged-out views
- Broke up urls.py into more logical groups
- Looks like at some point documents.html was reverted to an earlier version, so updates to that have been re-applied

## Guidance to review

- Navigate each page and check that the links work
- Check that you can't login twice

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
