### PR TITLE
Add condition to use small instance type for non prod env.

### DIFF
--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -1,6 +1,6 @@
 locals {
-  record_prefix        = terraform.workspace == "prod" ? var.project_name : "${var.project_name}-${terraform.workspace}"
-  django_host          = "${local.record_prefix}.${var.domain_name}"
+  record_prefix = terraform.workspace == "prod" ? var.project_name : "${var.project_name}-${terraform.workspace}"
+  django_host   = "${local.record_prefix}.${var.domain_name}"
 
   environment_variables = {
     "ELASTIC__API_KEY" : var.elastic_api_key,
@@ -17,23 +17,23 @@ locals {
     "DJANGO_SECRET_KEY" : var.django_secret_key,
     "POSTGRES_PASSWORD" : var.postgres_password,
     "POSTGRES_USER" : module.rds.rds_instance_username,
-    "POSTGRES_PASSWORD": module.rds.rds_instance_db_password,
+    "POSTGRES_PASSWORD" : module.rds.rds_instance_db_password,
     "POSTGRES_DB" : module.rds.db_instance_name,
     "POSTGRES_HOST" : module.rds.db_instance_address,
     "CORE_API_HOST" : "http://${aws_service_discovery_service.service_discovery_service.name}.${aws_service_discovery_private_dns_namespace.private_dns_namespace.name}",
-    "CORE_API_PORT": 5002,
-    "ENVIRONMENT": upper(terraform.workspace),
-    "DJANGO_SETTINGS_MODULE": "redbox_app.settings",
-    "DEBUG": true,
-    "AWS_REGION": var.region,
+    "CORE_API_PORT" : 5002,
+    "ENVIRONMENT" : upper(terraform.workspace),
+    "DJANGO_SETTINGS_MODULE" : "redbox_app.settings",
+    "DEBUG" : true,
+    "AWS_REGION" : var.region,
     "OPENAI_API_KEY" : var.openai_api_key,
     "FROM_EMAIL" : var.from_email,
-    "GOVUK_NOTIFY_PLAIN_EMAIL_TEMPLATE_ID": var.govuk_notify_plain_email_template_id
+    "GOVUK_NOTIFY_PLAIN_EMAIL_TEMPLATE_ID" : var.govuk_notify_plain_email_template_id
     "GOVUK_NOTIFY_API_KEY" : var.govuk_notify_api_key,
-    "EMAIL_BACKEND_TYPE": "GOVUKNOTIFY",
-    "USE_STREAMING": false,
-    "DJANGO_LOG_LEVEL": "DEBUG",
-    "COMPRESSION_ENABLED": true
+    "EMAIL_BACKEND_TYPE" : "GOVUKNOTIFY",
+    "USE_STREAMING" : false,
+    "DJANGO_LOG_LEVEL" : "DEBUG",
+    "COMPRESSION_ENABLED" : true
   }
 }
 
@@ -93,7 +93,7 @@ module "django-app" {
   prefix             = "redbox"
   ecr_repository_uri = "${var.ecr_repository_uri}/redbox-django-app"
   ecs_cluster_id     = module.cluster.ecs_cluster_id
-  health_check       = {
+  health_check = {
     healthy_threshold   = 3
     unhealthy_threshold = 3
     accepted_response   = "200"
@@ -113,18 +113,18 @@ module "django-app" {
 
 
 module "core_api" {
-  registry_arn = aws_service_discovery_service.service_discovery_service.arn
-  memory             = 4096
-  cpu                = 2048
-  create_listener    = false
-  create_networking  = false
-  source             = "../../../i-ai-core-infrastructure//modules/ecs"
-  project_name       = "core-api"
-  image_tag          = var.image_tag
-  prefix             = "redbox"
-  ecr_repository_uri = "${var.ecr_repository_uri}/redbox-core-api"
-  ecs_cluster_id     = module.cluster.ecs_cluster_id
-  health_check       = {
+  service_discovery_service_arn = aws_service_discovery_service.service_discovery_service.arn
+  memory                        = 4096
+  cpu                           = 2048
+  create_listener               = false
+  create_networking             = false
+  source                        = "../../../i-ai-core-infrastructure//modules/ecs"
+  project_name                  = "core-api"
+  image_tag                     = var.image_tag
+  prefix                        = "redbox"
+  ecr_repository_uri            = "${var.ecr_repository_uri}/redbox-core-api"
+  ecs_cluster_id                = module.cluster.ecs_cluster_id
+  health_check = {
     healthy_threshold   = 3
     unhealthy_threshold = 3
     accepted_response   = "200"
@@ -153,7 +153,7 @@ module "worker" {
   prefix             = "redbox"
   ecr_repository_uri = "${var.ecr_repository_uri}/redbox-worker"
   ecs_cluster_id     = module.cluster.ecs_cluster_id
-  health_check       = {
+  health_check = {
     healthy_threshold   = 3
     unhealthy_threshold = 3
     accepted_response   = "200"

--- a/infrastructure/aws/rds.tf
+++ b/infrastructure/aws/rds.tf
@@ -14,7 +14,7 @@ module "rds" {
   private_subnet_ids_list = data.terraform_remote_state.vpc.outputs.private_subnets
   public_subnet_ids_list  = data.terraform_remote_state.vpc.outputs.public_subnets
   vpc_id                  = data.terraform_remote_state.vpc.outputs.vpc_id
-  instance_type           = var.env != "prod" ? "db.t2.small" : "db.t3.large"
+  instance_type           = var.env != "prod" ? "db.t3.micro" : "db.t3.large"
   service_sg_ids = [
     module.core_api.ecs_sg_id,
     module.worker.ecs_sg_id,

--- a/infrastructure/aws/rds.tf
+++ b/infrastructure/aws/rds.tf
@@ -14,7 +14,7 @@ module "rds" {
   private_subnet_ids_list = data.terraform_remote_state.vpc.outputs.private_subnets
   public_subnet_ids_list  = data.terraform_remote_state.vpc.outputs.public_subnets
   vpc_id                  = data.terraform_remote_state.vpc.outputs.vpc_id
-  instance_type           = "db.t3.large"
+  instance_type           = var.env != "prod" ? "db.t2.small" : "db.t3.large"
   service_sg_ids = [
     module.core_api.ecs_sg_id,
     module.worker.ecs_sg_id,


### PR DESCRIPTION
## Context

The instance type of postgres is defined as `db.t3.large` for all prod and non-prod environment. The dev should be using the smaller instance to save cost. 

## Changes proposed in this pull request

Add a condition based on environment to use small instance for non prod environment. 

## Guidance to review



## Relevant links

- https://github.com/i-dot-ai/i-ai-core-infrastructure/issues/251

## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests
