### PR TITLE
Feature/daphne-webserver

### DIFF
--- a/django_app/Dockerfile
+++ b/django_app/Dockerfile
@@ -39,7 +39,7 @@ COPY django_app/ .
 COPY --from=npm-packages /src/node_modules/ frontend/node_modules/
 COPY --from=poetry-packages /src/venv ./venv
 
-ENV DJANGO_SETTINGS_MODULE='redbox_app.settings.py'
+ENV DJANGO_SETTINGS_MODULE='redbox_app.settings'
 ENV PYTHONPATH "${PYTHONPATH}:/."
 
 EXPOSE 8090

--- a/django_app/poetry.lock
+++ b/django_app/poetry.lock
@@ -1284,27 +1284,6 @@ files = [
 python-dateutil = ">=2.7"
 
 [[package]]
-name = "gunicorn"
-version = "22.0.0"
-description = "WSGI HTTP Server for UNIX"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "gunicorn-22.0.0-py3-none-any.whl", hash = "sha256:350679f91b24062c86e386e198a15438d53a7a8207235a78ba1b53df4c4378d9"},
-    {file = "gunicorn-22.0.0.tar.gz", hash = "sha256:4a0b436239ff76fb33f11c07a16482c521a7e09c1ce3cc293c2330afe01bec63"},
-]
-
-[package.dependencies]
-packaging = "*"
-
-[package.extras]
-eventlet = ["eventlet (>=0.24.1,!=0.36.0)"]
-gevent = ["gevent (>=1.4.0)"]
-setproctitle = ["setproctitle"]
-testing = ["coverage", "eventlet", "gevent", "pytest", "pytest-cov"]
-tornado = ["tornado (>=0.2)"]
-
-[[package]]
 name = "humanize"
 version = "4.9.0"
 description = "Python humanize utilities"
@@ -3050,4 +3029,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11.2,<3.13"
-content-hash = "9df681d0c9f661e89b9303ca67cb2b1fdf4eaced4cd6234ce67db2b4dabbfa9d"
+content-hash = "dbb2bd764ddda05a504a1512dc9a20e29539a9e8f40ee7793f5b8680f0a9d834"

--- a/django_app/pyproject.toml
+++ b/django_app/pyproject.toml
@@ -35,7 +35,6 @@ django-allauth = "^0.61.1"
 humanize = "^4.9.0"
 channels = {extras = ["daphne"], version = "^4.1.0"}
 django-gov-notify = "^0.5.0"
-gunicorn = "^22.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"

--- a/django_app/redbox_app/asgi.py
+++ b/django_app/redbox_app/asgi.py
@@ -14,9 +14,13 @@ from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
 from django.core.asgi import get_asgi_application
 
-from .routing import websocket_urlpatterns
-
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "redbox_app.settings")
+# Initialize Django ASGI application early to ensure the AppRegistry
+# is populated before importing code that may import ORM models.
+django_asgi_app = get_asgi_application()
+
+# https://github.com/django/daphne/issues/347#issuecomment-733132711
+from redbox_app.routing import websocket_urlpatterns  # noqa: E402
 
 application = ProtocolTypeRouter(
     {

--- a/django_app/redbox_app/gunicorn.py
+++ b/django_app/redbox_app/gunicorn.py
@@ -1,4 +1,0 @@
-workers = 1
-bind = "0.0.0.0:8090"
-accesslog = "-"
-errorlog = "-"

--- a/django_app/start.sh
+++ b/django_app/start.sh
@@ -5,5 +5,4 @@ venv/bin/django-admin collectstatic --noinput
 venv/bin/django-admin compress --force --engine jinja2
 venv/bin/django-admin assign_superuser_status
 
-exec venv/bin/gunicorn -c ./redbox_app/gunicorn.py redbox_app.wsgi
 exec venv/bin/daphne -p 8090 redbox_app.asgi:application

--- a/django_app/start.sh
+++ b/django_app/start.sh
@@ -6,3 +6,4 @@ venv/bin/django-admin compress --force --engine jinja2
 venv/bin/django-admin assign_superuser_status
 
 exec venv/bin/gunicorn -c ./redbox_app/gunicorn.py redbox_app.wsgi
+exec venv/bin/daphne -p 8090 redbox_app.asgi:application


### PR DESCRIPTION
## Context

As a User I want to use the Daphene webserver so that I can have chat streamed

## Changes proposed in this pull request

* `gunicorn` removed
* followed this https://channels.readthedocs.io/en/stable/deploying.html to ensure that the ASGI is set up before models

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
