### PR TITLE
Use document unique name for minio download link

### DIFF
--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -95,7 +95,7 @@ class File(UUIDPrimaryKeyBase, TimeStampedModel):
                 ClientMethod="get_object",
                 Params={
                     "Bucket": settings.AWS_STORAGE_BUCKET_NAME,
-                    "Key": self.name,
+                    "Key": self.unique_name,
                 },
             )
             return URL(url)


### PR DESCRIPTION
Document unique name is needed to generate the downloadable url locally so that the file can be found in minio