### PR TITLE
Change h1 for magic link page

### DIFF
--- a/django_app/redbox_app/templates/magic_link/logmein.html
+++ b/django_app/redbox_app/templates/magic_link/logmein.html
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-l">Sign in - confirmation</h1>
+      <h1 class="govuk-heading-l">Sign in to Redbox Copilot</h1>
 
       <form method="POST" action="{{ link.get_absolute_url() }}">
         {{ csrf_input }}


### PR DESCRIPTION
## Context

Updating the page title as per https://technologyprogramme.atlassian.net/browse/REDBOX-250?atlOrigin=eyJpIjoiMzFkNzZhNDlkNjQ3NDY2MTkzYzViZjA5NjE2ZjU1YzciLCJwIjoiaiJ9

## Guidance to review

Sign-in. Check the page you get to immediately after following the link has this title:
![image](https://github.com/i-dot-ai/redbox-copilot/assets/1634605/6a24a826-1cbd-47e2-9ad2-4508f7395be7)
