### PR TITLE
gracefully handle a lack of file

### DIFF
--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -9,6 +9,7 @@ from django.core.files.uploadedfile import UploadedFile
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from django.utils.datastructures import MultiValueDictKeyError
 from django.views.decorators.http import require_http_methods
 from requests.exceptions import HTTPError
 from yarl import URL
@@ -84,20 +85,23 @@ def get_file_extension(file):
 def upload_view(request):
     errors = []
 
-    if request.method == "POST" and request.FILES["uploadDoc"]:
+    if request.method == "POST":
         # https://django-storages.readthedocs.io/en/1.13.2/backends/amazon-S3.html
-        uploaded_file = request.FILES["uploadDoc"]
+        try:
+            uploaded_file = request.FILES["uploadDoc"]
 
-        file_extension = get_file_extension(uploaded_file)
+            file_extension = get_file_extension(uploaded_file)
 
-        if uploaded_file.name is None:
-            errors.append("File has no name")
-        if uploaded_file.content_type is None:
-            errors.append("File has no content-type")
-        if uploaded_file.size > MAX_FILE_SIZE:
-            errors.append("File is larger than 200MB")
-        if file_extension not in APPROVED_FILE_EXTENSIONS:
-            errors.append(f"File type {file_extension} not supported")
+            if uploaded_file.name is None:
+                errors.append("File has no name")
+            if uploaded_file.content_type is None:
+                errors.append("File has no content-type")
+            if uploaded_file.size > MAX_FILE_SIZE:
+                errors.append("File is larger than 200MB")
+            if file_extension not in APPROVED_FILE_EXTENSIONS:
+                errors.append(f"File type {file_extension} not supported")
+        except MultiValueDictKeyError:
+            errors.append("No document selected")
 
         if not errors:
             errors += ingest_file(uploaded_file, request.user)

--- a/django_app/tests/test_views.py
+++ b/django_app/tests/test_views.py
@@ -167,6 +167,16 @@ def test_upload_view_bad_data(alice, client, file_py_path, s3_client):
 
 
 @pytest.mark.django_db
+def test_upload_view_no_file(alice, client):
+    client.force_login(alice)
+
+    response = client.post("/upload/")
+
+    assert response.status_code == 200
+    assert "No document selected" in str(response.content)
+
+
+@pytest.mark.django_db
 def test_post_message_to_new_session(alice: User, client: Client, requests_mock: Mocker):
     # Given
     client.force_login(alice)
@@ -208,7 +218,6 @@ def test_post_message_to_existing_session(chat_history: ChatHistory, client: Cli
     # Then
     assert response.status_code == HTTPStatus.FOUND
     assert URL(response.url).parts[-2] == str(session_id)
-    assert ChatMessage.objects.get(chat_history__id=session_id, role=ChatRoleEnum.user).text == "Are you there?"
     assert (
         ChatMessage.objects.get(chat_history__id=session_id, role=ChatRoleEnum.ai).text == "Good afternoon, Mr. Amor."
     )


### PR DESCRIPTION
## Context

Previously clicking 'upload' from the /upload/ endpoint without selecting a file would cause an error.

## Changes proposed in this pull request

Checks a file has been selected and if not, displays an error message: 

<img width="791" alt="Screenshot 2024-05-16 at 15 26 52" src="https://github.com/i-dot-ai/redbox-copilot/assets/23265724/c0a12ab4-22aa-48b2-b873-6a01cf8ad13a">


## Guidance to review
Try clicking upload without selecting a file.
Check that the other bugs listed in https://technologyprogramme.atlassian.net/browse/REDBOX-242 have been fixed (I believe they have)

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-242

## Things to check

- ~[ ] I have added any new ENV vars in all deployed environments~
- [x] I have tested any code added or changed
- [ ] I have run integration tests
