### PR TITLE
environment specific elastic index

### DIFF
--- a/core_api/src/routes/file.py
+++ b/core_api/src/routes/file.py
@@ -51,7 +51,7 @@ file_publisher = FilePublisher(router.broker, env.ingest_queue_name)
 # === Storage ===
 
 es = env.elasticsearch_client()
-storage_handler = ElasticsearchStorageHandler(es_client=es, root_index="redbox-data")
+storage_handler = ElasticsearchStorageHandler(es_client=es, root_index=f"redbox-data-{env.environment}")
 
 
 file_app = FastAPI(

--- a/core_api/src/routes/file.py
+++ b/core_api/src/routes/file.py
@@ -51,7 +51,7 @@ file_publisher = FilePublisher(router.broker, env.ingest_queue_name)
 # === Storage ===
 
 es = env.elasticsearch_client()
-storage_handler = ElasticsearchStorageHandler(es_client=es, root_index=f"redbox-data-{env.environment}")
+storage_handler = ElasticsearchStorageHandler(es_client=es, root_index=env.elastic_index)
 
 
 file_app = FastAPI(

--- a/core_api/tests/conftest.py
+++ b/core_api/tests/conftest.py
@@ -56,7 +56,7 @@ def headers(alice):
 
 @pytest.fixture
 def elasticsearch_storage_handler(es_client):
-    yield ElasticsearchStorageHandler(es_client=es_client, root_index="redbox-data")
+    yield ElasticsearchStorageHandler(es_client=es_client, root_index=env.elastic_index)
 
 
 @pytest.fixture

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -11,9 +11,6 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.datastructures import MultiValueDictKeyError
 from django.views.decorators.http import require_http_methods
-from requests.exceptions import HTTPError
-from yarl import URL
-
 from redbox_app.redbox_core.client import CoreApiClient
 from redbox_app.redbox_core.models import (
     ChatHistory,
@@ -23,6 +20,8 @@ from redbox_app.redbox_core.models import (
     ProcessingStatusEnum,
     User,
 )
+from requests.exceptions import HTTPError
+from yarl import URL
 
 logger = logging.getLogger(__name__)
 

--- a/django_app/tests/test_views.py
+++ b/django_app/tests/test_views.py
@@ -6,9 +6,6 @@ import pytest
 from botocore.exceptions import ClientError
 from django.conf import settings
 from django.test import Client
-from requests_mock import Mocker
-from yarl import URL
-
 from redbox_app.redbox_core.models import (
     ChatHistory,
     ChatMessage,
@@ -17,6 +14,8 @@ from redbox_app.redbox_core.models import (
     ProcessingStatusEnum,
     User,
 )
+from requests_mock import Mocker
+from yarl import URL
 
 logger = logging.getLogger(__name__)
 

--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -34,7 +34,6 @@ locals {
     "DJANGO_LOG_LEVEL" : "DEBUG",
     "COMPRESSION_ENABLED" : true,
     "CONTACT_EMAIL": var.contact_email,
-    "SUPERUSER_EMAIL": "george.burton@cabinetoffice.gov.uk"
   }
 }
 
@@ -90,7 +89,7 @@ module "django-app" {
   create_networking  = true
   source             = "../../../i-ai-core-infrastructure//modules/ecs"
   project_name       = "django-app"
-  image_tag          = "6ee0714418cffaf0c7739a873683ec784cd857de"
+  image_tag          = var.image_tag
   prefix             = "redbox"
   ecr_repository_uri = "${var.ecr_repository_uri}/redbox-django-app"
   ecs_cluster_id     = module.cluster.ecs_cluster_id
@@ -121,7 +120,7 @@ module "core_api" {
   create_networking             = false
   source                        = "../../../i-ai-core-infrastructure//modules/ecs"
   project_name                  = "core-api"
-  image_tag                     = "6ee0714418cffaf0c7739a873683ec784cd857de"
+  image_tag                     = var.image_tag
   prefix                        = "redbox"
   ecr_repository_uri            = "${var.ecr_repository_uri}/redbox-core-api"
   ecs_cluster_id                = module.cluster.ecs_cluster_id
@@ -150,7 +149,7 @@ module "worker" {
   create_networking  = false
   source             = "../../../i-ai-core-infrastructure//modules/ecs"
   project_name       = "worker"
-  image_tag          = "6ee0714418cffaf0c7739a873683ec784cd857de"
+  image_tag          = var.image_tag
   prefix             = "redbox"
   ecr_repository_uri = "${var.ecr_repository_uri}/redbox-worker"
   ecs_cluster_id     = module.cluster.ecs_cluster_id

--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -34,6 +34,7 @@ locals {
     "DJANGO_LOG_LEVEL" : "DEBUG",
     "COMPRESSION_ENABLED" : true,
     "CONTACT_EMAIL": var.contact_email,
+    "SUPERUSER_EMAIL": "george.burton@cabinetoffice.gov.uk"
   }
 }
 
@@ -89,7 +90,7 @@ module "django-app" {
   create_networking  = true
   source             = "../../../i-ai-core-infrastructure//modules/ecs"
   project_name       = "django-app"
-  image_tag          = var.image_tag
+  image_tag          = "6ee0714418cffaf0c7739a873683ec784cd857de"
   prefix             = "redbox"
   ecr_repository_uri = "${var.ecr_repository_uri}/redbox-django-app"
   ecs_cluster_id     = module.cluster.ecs_cluster_id
@@ -120,7 +121,7 @@ module "core_api" {
   create_networking             = false
   source                        = "../../../i-ai-core-infrastructure//modules/ecs"
   project_name                  = "core-api"
-  image_tag                     = var.image_tag
+  image_tag                     = "6ee0714418cffaf0c7739a873683ec784cd857de"
   prefix                        = "redbox"
   ecr_repository_uri            = "${var.ecr_repository_uri}/redbox-core-api"
   ecs_cluster_id                = module.cluster.ecs_cluster_id
@@ -149,7 +150,7 @@ module "worker" {
   create_networking  = false
   source             = "../../../i-ai-core-infrastructure//modules/ecs"
   project_name       = "worker"
-  image_tag          = var.image_tag
+  image_tag          = "6ee0714418cffaf0c7739a873683ec784cd857de"
   prefix             = "redbox"
   ecr_repository_uri = "${var.ecr_repository_uri}/redbox-worker"
   ecs_cluster_id     = module.cluster.ecs_cluster_id

--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -15,7 +15,6 @@ locals {
 
     # django stuff
     "DJANGO_SECRET_KEY" : var.django_secret_key,
-    "POSTGRES_PASSWORD" : var.postgres_password,
     "POSTGRES_USER" : module.rds.rds_instance_username,
     "POSTGRES_PASSWORD" : module.rds.rds_instance_db_password,
     "POSTGRES_DB" : module.rds.db_instance_name,

--- a/infrastructure/aws/variables.tf
+++ b/infrastructure/aws/variables.tf
@@ -94,10 +94,6 @@ variable "openai_api_key" {
   description = "OPENAI api key"
 }
 
-variable "postgres_password" {
-  type        = string
-  description = "postgres password"
-}
 
 variable "project_name" {
   type        = string

--- a/redbox/models/settings.py
+++ b/redbox/models/settings.py
@@ -135,3 +135,7 @@ class Settings(BaseSettings):
     @property
     def redis_url(self) -> str:
         return f"redis://{self.redis_host}:{self.redis_port}/"
+
+    @property
+    def elastic_index(self) -> str:
+        return f"redbox-data-{self.environment.lower()}"

--- a/worker/src/app.py
+++ b/worker/src/app.py
@@ -25,7 +25,7 @@ publisher = router.broker.publisher(env.embed_queue_name)
 
 def get_storage_handler():
     es = env.elasticsearch_client()
-    return ElasticsearchStorageHandler(es_client=es, root_index="redbox-data")
+    return ElasticsearchStorageHandler(es_client=es, root_index=env.elastic_index)
 
 
 def get_model() -> SentenceTransformerDB:

--- a/worker/tests/conftest.py
+++ b/worker/tests/conftest.py
@@ -83,12 +83,12 @@ def app_client():
 def elasticsearch_storage_handler(
     es_client,
 ) -> YieldFixture[ElasticsearchStorageHandler]:
-    yield ElasticsearchStorageHandler(es_client=es_client, root_index="redbox-data")
+    yield ElasticsearchStorageHandler(es_client=es_client, root_index=env.elastic_index)
 
 
 @pytest.fixture
 def chunk() -> YieldFixture[Chunk]:
-    test_chunk = Chunk(parent_file_uuid=uuid4(), index=1, text="test_text", creator_user_uuid=uuid4())
+    test_chunk = Chunk(parent_file_uuid=uuid4(), index=1, text=env.elastic_index, creator_user_uuid=uuid4())
     yield test_chunk
 
 


### PR DESCRIPTION
## Context

As an infra engineer I want the indexes in our single elasticseach instance to include the environment name so that users data is not shared across environments 

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/9123932880
