### PR TITLE
bugfix/remove-unused-postgres-password

### DIFF
--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -15,7 +15,6 @@ locals {
 
     # django stuff
     "DJANGO_SECRET_KEY" : var.django_secret_key,
-    "POSTGRES_PASSWORD" : var.postgres_password,
     "POSTGRES_USER" : module.rds.rds_instance_username,
     "POSTGRES_PASSWORD" : module.rds.rds_instance_db_password,
     "POSTGRES_DB" : module.rds.db_instance_name,

--- a/infrastructure/aws/variables.tf
+++ b/infrastructure/aws/variables.tf
@@ -94,10 +94,6 @@ variable "openai_api_key" {
   description = "OPENAI api key"
 }
 
-variable "postgres_password" {
-  type        = string
-  description = "postgres password"
-}
 
 variable "project_name" {
   type        = string


### PR DESCRIPTION
## Context

As an Engineer I do not want unused / duplicate variables

## Changes proposed in this pull request

* `postgress_password` has been removed from the variables
* a duplicate instance of `postgress_password` has been removed from `ecs.tf`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
