### PR TITLE
call core api delete from django delete

### DIFF
--- a/django_app/redbox_app/redbox_core/client.py
+++ b/django_app/redbox_app/redbox_core/client.py
@@ -74,3 +74,10 @@ class CoreApiClient:
         response.raise_for_status()
         response_data = response.json(object_hook=lambda d: SimpleNamespace(**d))
         return response_data
+
+    def delete_file(self, file_id: UUID, user: User) -> SimpleNamespace:
+        url = self.url / "file" / str(file_id)
+        response = requests.delete(url, headers={"Authorization": user.get_bearer_token()}, timeout=60)
+        response.raise_for_status()
+        response_data = response.json(object_hook=lambda d: SimpleNamespace(**d))
+        return response_data

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -156,12 +156,12 @@ def remove_doc_view(request, doc_id: uuid):
             core_api.delete_file(file.core_file_uuid, request.user)
         except HTTPError as e:
             logger.error("Error deleting file object %s.", file, exc_info=e)
-            errors.append("failed to connect to core-api")
+            errors.append("There was an error deleting this file")
 
         else:
             logger.info("Removing document: %s", request.POST["doc_id"])
             file.delete()
-        return redirect("documents")
+            return redirect("documents")
 
     return render(
         request,

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -156,7 +156,6 @@ def remove_doc_view(request, doc_id: uuid):
             core_api.delete_file(file.core_file_uuid, request.user)
         except HTTPError as e:
             logger.error("Error deleting file object %s.", file, exc_info=e)
-            file.delete()
             errors.append("failed to connect to core-api")
 
         else:

--- a/django_app/redbox_app/templates/macros/govuk-error-summary.html
+++ b/django_app/redbox_app/templates/macros/govuk-error-summary.html
@@ -1,0 +1,18 @@
+{% macro govukErrorSummary(title="There is a problem", error_list=None, heading_level=2) %}
+{% if error_list %}
+  <div class="govuk-error-summary" data-module="govuk-error-summary">
+    <div role="alert">
+      <h{{ heading_level }} class="govuk-error-summary__title">
+        {{ title }}
+      </h{{ heading_level }}>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          {% for error in error_list %}
+            <li>{{error}}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+{% endif %}
+{% endmacro %}

--- a/django_app/redbox_app/templates/remove-doc.html
+++ b/django_app/redbox_app/templates/remove-doc.html
@@ -2,6 +2,7 @@
 
 {% extends "base.html" %}
 {% from "macros/govuk-button.html" import govukButton %}
+{% from "macros/govuk-error-summary.html" import govukErrorSummary %}
 
 {% block content %}
 
@@ -17,6 +18,8 @@
     <input type="hidden" name="doc_id" value="{{ doc_id }}">
 
     <h1 class="govuk-heading-m">Are you sure you want to remove this document?</h1>
+
+    {{ govukErrorSummary(error_list=errors) }}
 
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">

--- a/django_app/tests/test_views.py
+++ b/django_app/tests/test_views.py
@@ -178,6 +178,49 @@ def test_upload_view_no_file(alice, client):
 
 
 @pytest.mark.django_db
+def test_remove_doc_view(client: Client, alice: User, file_pdf_path: str, s3_client: Client, requests_mock: Mocker):
+    file_name = file_pdf_path.split("/")[-1]
+
+    client.force_login(alice)
+    # we begin by removing any file in minio that has this key
+    s3_client.delete_object(Bucket=settings.BUCKET_NAME, Key=file_name.replace(" ", "_"))
+
+    previous_count = count_s3_objects(s3_client)
+
+    mocked_response = {
+        "key": file_name,
+        "bucket": settings.BUCKET_NAME,
+        "uuid": str(uuid.uuid4()),
+    }
+    requests_mock.post(
+        f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file",
+        status_code=201,
+        json=mocked_response,
+    )
+
+    with open(file_pdf_path, "rb") as f:
+        # create file before testing deletion
+        client.post("/upload/", {"uploadDoc": f})
+        assert file_exists(s3_client, file_name)
+        assert count_s3_objects(s3_client) == previous_count + 1
+
+        new_file = File.objects.filter(user=alice).order_by("-created_at")[0]
+        requests_mock.delete(
+            f"http://{settings.CORE_API_HOST}:{settings.CORE_API_PORT}/file/{new_file.core_file_uuid}",
+            status_code=201,
+            json=mocked_response,
+        )
+
+        client.post(f"/remove-doc/{new_file.id}", {"doc_id": new_file.id})
+        assert not file_exists(s3_client, file_name)
+        assert count_s3_objects(s3_client) == previous_count
+        assert requests_mock.request_history[-1].method == "DELETE"
+
+        with pytest.raises(File.DoesNotExist):
+            File.objects.get(id=new_file.id)
+
+
+@pytest.mark.django_db
 def test_post_message_to_new_session(alice: User, client: Client, requests_mock: Mocker):
     # Given
     client.force_login(alice)


### PR DESCRIPTION
## Context

Currently the frontend deletion of a file only deletes the file from the Django and S3 storage, but not the Elastic storage.

## Changes proposed in this pull request
Deleting a file from the user interface propagates a call to core-api to delete the file and its chunks. If that API request fails, then the file will not delete from the Django database.

If the call to the API fails, the user will see this view: 
<img width="866" alt="Screenshot 2024-05-20 at 12 31 30" src="https://github.com/i-dot-ai/redbox-copilot/assets/23265724/0887b6ea-a20c-4b26-95a2-f74395b8b96a">


## Guidance to review

Try deleting files from django.

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-256

## Things to check

- ~[ ] I have added any new ENV vars in all deployed environments~
- [x] I have tested any code added or changed
- [ ] I have run integration tests
