### PR TITLE
Update doc status colour when complete

### DIFF
--- a/django_app/frontend/js/documents.js
+++ b/django_app/frontend/js/documents.js
@@ -13,7 +13,7 @@ Alpine.data('file-status', () => ({
         this.status = this.$el.textContent || '';
 
         const checkStatus = async () => {
-            
+
             // UPDATE THESE AS REQUIRED
             const FILE_STATUS_ENDPOINT = '/file-status';
             const CHECK_INTERVAL_MS = 5000;
@@ -23,7 +23,10 @@ Alpine.data('file-status', () => ({
             if (response.ok) {
                 this.status = responseText["status"];
             }
-            if (this.status !== 'complete') {
+            if (this.status.toLowerCase() === 'complete') {
+                this.$el.classList.add('govuk-tag--green');
+                this.$el.classList.remove('govuk-tag--yellow');
+            } else {
                 window.setTimeout(checkStatus, CHECK_INTERVAL_MS);
             }
 


### PR DESCRIPTION
## Context

The doc status background colour should change to green once complete.

The doc status design is going to change soon, but it'd be good to get this version working as intended, hence the update.

![image](https://github.com/i-dot-ai/redbox-copilot/assets/1634605/8e728d5a-a979-43cd-b03f-2e522972409e)
