### PR TITLE
bugfix/move-from-pubsub-to-fifo-arch

### DIFF
--- a/core_api/src/publisher_handler.py
+++ b/core_api/src/publisher_handler.py
@@ -20,4 +20,4 @@ class FilePublisher:
             # we only do this once
             await self.broker.connect()
             self.connected = True
-        await self.broker.publish(file, self.queue_name)
+        await self.broker.publish(file, list=self.queue_name)

--- a/worker/src/app.py
+++ b/worker/src/app.py
@@ -21,7 +21,7 @@ env = Settings()
 
 broker = RedisBroker(url=env.redis_url)
 
-publisher = broker.publisher(env.embed_queue_name)
+publisher = broker.publisher(list=env.embed_queue_name)
 
 
 @asynccontextmanager
@@ -65,7 +65,7 @@ async def ingest(
     return items
 
 
-@broker.subscriber(channel=env.embed_queue_name)
+@broker.subscriber(list=env.embed_queue_name)
 async def embed(
     queue_item: EmbedQueueItem,
     storage_handler: ElasticsearchStorageHandler = Context(),
@@ -83,6 +83,8 @@ async def embed(
         return
     chunk.embedding = embedded_sentences.data[0].embedding
     storage_handler.update_item(chunk)
+
+    logging.info("embedded: %s", chunk.uuid)
 
 
 app = FastStream(broker=broker, lifespan=lifespan)

--- a/worker/src/app.py
+++ b/worker/src/app.py
@@ -36,7 +36,7 @@ async def lifespan(context: ContextRepo):
     yield
 
 
-@broker.subscriber(channel=env.ingest_queue_name)
+@broker.subscriber(list=env.ingest_queue_name)
 async def ingest(
     file: File,
     storage_handler: ElasticsearchStorageHandler = Context(),

--- a/worker/tests/test_app.py
+++ b/worker/tests/test_app.py
@@ -20,7 +20,7 @@ async def test_ingest_file(s3_client, es_client, embedding_model, file):
     storage_handler.write_item(file)
 
     async with TestRedisBroker(broker) as br, TestApp(app):
-        await br.publish(file, channel=env.ingest_queue_name)
+        await br.publish(file, list=env.ingest_queue_name)
 
         file = storage_handler.read_item(
             item_uuid=file.uuid,
@@ -41,7 +41,7 @@ async def test_embed_item_callback(elasticsearch_storage_handler, embed_queue_it
     assert unembedded_chunk.embedding is None
 
     async with TestRedisBroker(broker) as br:
-        await br.publish(embed_queue_item, channel=env.embed_queue_name)
+        await br.publish(embed_queue_item, list=env.embed_queue_name)
 
     embedded_chunk = elasticsearch_storage_handler.read_item(embed_queue_item.chunk_uuid, "Chunk")
     assert embedded_chunk.embedding is not None


### PR DESCRIPTION
## Context

As a user I want each chunk to be embedded only once so that unnecessary work isnt performed

## Changes proposed in this pull request

previously we were using a pubsub architecture (called `channel` in faststream) where by every message is published to all subscribers, that is to say that each embedder received the same instruction to embed the same doc.

We have moved to a `fifo` (First in First Out) architecture (called `list` in fastream) whereby messages are processed in order.

## Guidance to review

run this locally and check that there are no duplicate logs starting with `embedded:...`

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/9157888905