### PR TITLE
feature/REDBOX-260-order-document-view

### DIFF
--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -64,7 +64,7 @@ def homepage_view(request):
 
 @login_required
 def documents_view(request):
-    files = File.objects.filter(user=request.user)
+    files = File.objects.filter(user=request.user).order_by("original_file")
 
     return render(
         request,

--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -89,7 +89,7 @@ module "django-app" {
   create_networking  = true
   source             = "../../../i-ai-core-infrastructure//modules/ecs"
   project_name       = "django-app"
-  image_tag          = var.image_tag
+  image_tag                     = "84fb575dfb19662f158f532b541aa4c4c60d3899"
   prefix             = "redbox"
   ecr_repository_uri = "${var.ecr_repository_uri}/redbox-django-app"
   ecs_cluster_id     = module.cluster.ecs_cluster_id
@@ -120,7 +120,7 @@ module "core_api" {
   create_networking             = false
   source                        = "../../../i-ai-core-infrastructure//modules/ecs"
   project_name                  = "core-api"
-  image_tag                     = var.image_tag
+  image_tag                     = "84fb575dfb19662f158f532b541aa4c4c60d3899"
   prefix                        = "redbox"
   ecr_repository_uri            = "${var.ecr_repository_uri}/redbox-core-api"
   ecs_cluster_id                = module.cluster.ecs_cluster_id
@@ -149,7 +149,7 @@ module "worker" {
   create_networking  = false
   source             = "../../../i-ai-core-infrastructure//modules/ecs"
   project_name       = "worker"
-  image_tag          = var.image_tag
+  image_tag                     = "84fb575dfb19662f158f532b541aa4c4c60d3899"
   prefix             = "redbox"
   ecr_repository_uri = "${var.ecr_repository_uri}/redbox-worker"
   ecs_cluster_id     = module.cluster.ecs_cluster_id

--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -89,7 +89,7 @@ module "django-app" {
   create_networking  = true
   source             = "../../../i-ai-core-infrastructure//modules/ecs"
   project_name       = "django-app"
-  image_tag                     = "84fb575dfb19662f158f532b541aa4c4c60d3899"
+  image_tag          = var.image_tag
   prefix             = "redbox"
   ecr_repository_uri = "${var.ecr_repository_uri}/redbox-django-app"
   ecs_cluster_id     = module.cluster.ecs_cluster_id
@@ -120,7 +120,7 @@ module "core_api" {
   create_networking             = false
   source                        = "../../../i-ai-core-infrastructure//modules/ecs"
   project_name                  = "core-api"
-  image_tag                     = "84fb575dfb19662f158f532b541aa4c4c60d3899"
+  image_tag                     = var.image_tag
   prefix                        = "redbox"
   ecr_repository_uri            = "${var.ecr_repository_uri}/redbox-core-api"
   ecs_cluster_id                = module.cluster.ecs_cluster_id
@@ -149,7 +149,7 @@ module "worker" {
   create_networking  = false
   source             = "../../../i-ai-core-infrastructure//modules/ecs"
   project_name       = "worker"
-  image_tag                     = "84fb575dfb19662f158f532b541aa4c4c60d3899"
+  image_tag          = var.image_tag
   prefix             = "redbox"
   ecr_repository_uri = "${var.ecr_repository_uri}/redbox-worker"
   ecs_cluster_id     = module.cluster.ecs_cluster_id


### PR DESCRIPTION
## Context

As a User I want the document view to be consistently ordered so that when I refresh the page my documents are in the same place

## Changes proposed in this pull request

I have added the following clause to the documents query

```python
order_by("original_file_name")
```

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
