### PR TITLE
Sorted documentsby created_at and added date field to documents page

### DIFF
--- a/django_app/frontend/iai.scss
+++ b/django_app/frontend/iai.scss
@@ -56,6 +56,9 @@
     box-shadow: none;
     padding: 13px 12px 12px 12px;
 }
+.govuk-table .govuk-button {
+    padding: 11px 10px 10px 10px;
+}
 
 /* FOOTER */
 .govuk-footer {

--- a/django_app/frontend/style.scss
+++ b/django_app/frontend/style.scss
@@ -49,6 +49,22 @@ body {
 
 
 /* Documents page */
+.iai-doclist-mobile__item {
+  border: 1px solid #b1b4b6;
+  border-radius: 0.25rem;
+  list-style-type: none;
+}
+.iai-doclist-desktop {
+  display: none;
+}
+@media (min-width: 448px) {
+  .iai-doclist-mobile {
+    display: none;
+  }
+  .iai-doclist-desktop {
+    display: block;
+  }
+}
 /* Use this if more than one button in Actions
 .iai-docs__actions .govuk-button {
   width: 100%;

--- a/django_app/redbox_app/jinja2.py
+++ b/django_app/redbox_app/jinja2.py
@@ -2,10 +2,12 @@ import datetime
 
 import humanize
 import jinja2
+import pytz
 from compressor.contrib.jinja2ext import CompressorExtension
 from django.conf import settings
 from django.templatetags.static import static
 from django.urls import reverse
+from django.utils.timezone import template_localtime
 from markdown_it import MarkdownIt
 
 # `js-default` setting required to sanitize inputs
@@ -47,6 +49,13 @@ def humanize_timedelta(minutes=0, hours_limit=200, too_large_msg=""):
         return humanize.precisedelta(delta, minimum_unit="minutes")
 
 
+def to_user_timezone(value):
+    # Assuming the user's timezone is stored in a variable called 'user_timezone'
+    # Replace 'Europe/London' with the actual timezone string for the user
+    user_tz = pytz.timezone("Europe/London")
+    return value.astimezone(user_tz).strftime("%H:%M %d/%m/%Y")
+
+
 def environment(**options):
     extra_options = {}
     env = jinja2.Environment(  # nosec B701 # noqa S701
@@ -62,6 +71,8 @@ def environment(**options):
             "static": static,
             "url": url,
             "humanize_timedelta": humanize_timedelta,
+            "template_localtime": template_localtime,
+            "to_user_timezone": to_user_timezone,
             "environment": settings.ENVIRONMENT,
         }
     )
@@ -70,6 +81,8 @@ def environment(**options):
             "static": static,
             "url": url,
             "humanize_timedelta": humanize_timedelta,
+            "template_localtime": template_localtime,
+            "to_user_timezone": to_user_timezone,
             "environment": settings.ENVIRONMENT,
         }
     )

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -65,7 +65,7 @@ def homepage_view(request):
 
 @login_required
 def documents_view(request):
-    files = File.objects.filter(user=request.user).order_by("original_file")
+    files = File.objects.filter(user=request.user).order_by("-created_at")
 
     return render(
         request,

--- a/django_app/redbox_app/templates/documents.html
+++ b/django_app/redbox_app/templates/documents.html
@@ -33,6 +33,7 @@
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header">File Name</th>
+            <th scope="col" class="govuk-table__header">Uploaded at</th>
             <th scope="col" class="govuk-table__header">Status</th>
             <th scope="col" class="govuk-table__header iai-doclist__actions">Actions</th>
           </tr>
@@ -41,6 +42,7 @@
           {% for file in files %}
             <tr class="govuk-table__row">
               <td class="govuk-table__cell govuk-!-padding-top-3">{{file.name}}</td>
+              <td class="govuk-table__cell govuk-!-padding-top-3">{{ file.created_at | to_user_timezone }}</td>
               <td class="govuk-table__cell govuk-!-padding-top-3">
                 {% if file.get_processing_status_text() | lower == 'complete' %}
                   <strong class="govuk-tag govuk-tag--green iai-docs__status">{{file.get_processing_status_text()}}</strong>

--- a/django_app/redbox_app/templates/documents.html
+++ b/django_app/redbox_app/templates/documents.html
@@ -18,7 +18,7 @@
 <div class="govuk-width-container">
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ govukNotificationBanner(
         title="Important",
         text_list=[
@@ -26,7 +26,44 @@
         ]
       ) }}
 
-      <table class="govuk-table iai-doclist">
+      {# Mobile docs list #}
+      <div class="iai-doclist-mobile">
+        <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Documents</h1>
+        <ul class="govuk-!-padding-0">
+          {% for file in files %}
+            <li class="iai-doclist-mobile__item govuk-!-margin-top-3 govuk-!-padding-3">
+              <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">File Name</dt>
+                  <dd class="govuk-summary-list__value">{{file.name}}</dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">Uploaded at</dt>
+                  <dd class="govuk-summary-list__value">{{ file.created_at | to_user_timezone }}</dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">Status</dt>
+                  <dd class="govuk-summary-list__value">
+                    {% if file.get_processing_status_text() | lower == 'complete' %}
+                      <strong class="govuk-tag govuk-tag--green iai-docs__status">{{ file.get_processing_status_text() }}</strong>
+                    {% else %}
+                      <strong class="govuk-tag govuk-tag--yellow iai-docs__status" x-data="file-status" data-id="{{file.id}}" x-text="status">{{ file.get_processing_status_text() }}</strong>
+                    {% endif %}
+                  </dd>
+                </div>
+              </dl>
+              {{ govukButton(
+                text="Remove" + "<span class=\"govuk-visually-hidden\">" + file.name + "</span>",
+                href=url('remove-doc', file.id),
+                classes="govuk-button--warning govuk-!-margin-bottom-0"
+              ) }}
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+
+      {# Desktop docs list #}
+      <table class="govuk-table iai-doclist-desktop">
         <caption class="govuk-table__caption govuk-table__caption--m">
           <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Documents</h1>
         </caption>
@@ -41,13 +78,13 @@
         <tbody class="govuk-table__body">
           {% for file in files %}
             <tr class="govuk-table__row">
-              <td class="govuk-table__cell govuk-!-padding-top-3">{{file.name}}</td>
+              <td class="govuk-table__cell govuk-!-padding-top-3">{{ file.name }}</td>
               <td class="govuk-table__cell govuk-!-padding-top-3">{{ file.created_at | to_user_timezone }}</td>
               <td class="govuk-table__cell govuk-!-padding-top-3">
                 {% if file.get_processing_status_text() | lower == 'complete' %}
-                  <strong class="govuk-tag govuk-tag--green iai-docs__status">{{file.get_processing_status_text()}}</strong>
+                  <strong class="govuk-tag govuk-tag--green iai-docs__status govuk-!-margin-top-0">{{ file.get_processing_status_text() }}</strong>
                 {% else %}
-                  <strong class="govuk-tag govuk-tag--yellow iai-docs__status" x-data="file-status" data-id="{{file.id}}" x-text="status">{{file.get_processing_status_text()}}</strong>
+                  <strong class="govuk-tag govuk-tag--yellow iai-docs__status govuk-!-margin-top-0" x-data="file-status" data-id="{{file.id}}" x-text="status">{{ file.get_processing_status_text() }}</strong>
                 {% endif %}
               </td>
               <td class="govuk-table__cell iai-docs__actions">


### PR DESCRIPTION
## Context

Documents should be sorted so most recent is first, and display the created datetime to the user

## Changes proposed in this pull request

- Added jinja2 filter for converting a datetime to localtime
- Added column to documents page to show created datetime

## Guidance to review

Add some documents and check the datetime shown on the documents page

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests


_Closing until Kevin can work with me on fixing the table layout on mobile_