### PR TITLE
Ensure feedback prompts are displayed as coming from Redbox (not User)

### DIFF
--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -82,12 +82,12 @@
         <div class="iai-response-feedback js-response-feedback">
           <feedback-buttons class="iai-response-feedback__buttons"></feedback-buttons>
           {{ message_box(
-            role = "AI",
+            role = "ai",
             text = "Thank you for your feedback",
             classes = "iai-response-feedback__thumbs-up"
           ) }}
           {{ message_box(
-            role = "AI",
+            role = "ai",
             text = "Ok. Can you let me know what wasn’t accurate? I can refine it again to make it more accurate.",
             classes = "iai-response-feedback__thumbs-down"
           ) }}


### PR DESCRIPTION
## Context

A small bugfix where clicking on the feedback buttons displayed the message as coming from the User.

## Changes proposed in this pull request

Ensure the messages are displayed as coming from Redbox

![image](https://github.com/i-dot-ai/redbox-copilot/assets/1634605/8ea35be8-24f3-4830-a185-46efad3a9716)


## Guidance to review

Click on the thumbs up/down icons and check it looks as per the screenshot
