### PR TITLE
Order chat by date

### DIFF
--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -11,6 +11,9 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.datastructures import MultiValueDictKeyError
 from django.views.decorators.http import require_http_methods
+from requests.exceptions import HTTPError
+from yarl import URL
+
 from redbox_app.redbox_core.client import CoreApiClient
 from redbox_app.redbox_core.models import (
     ChatHistory,
@@ -20,8 +23,6 @@ from redbox_app.redbox_core.models import (
     ProcessingStatusEnum,
     User,
 )
-from requests.exceptions import HTTPError
-from yarl import URL
 
 logger = logging.getLogger(__name__)
 core_api = CoreApiClient(host=settings.CORE_API_HOST, port=settings.CORE_API_PORT)
@@ -176,7 +177,7 @@ def chats_view(request: HttpRequest, chat_id: uuid = None):
 
     messages = []
     if chat_id:
-        messages = ChatMessage.objects.filter(chat_history__id=chat_id)
+        messages = ChatMessage.objects.filter(chat_history__id=chat_id).order_by("created_at")
     endpoint = URL.build(scheme="ws", host=request.get_host(), path=r"/ws/chat/")
     context = {
         "chat_id": chat_id,

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -11,9 +11,6 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.datastructures import MultiValueDictKeyError
 from django.views.decorators.http import require_http_methods
-from requests.exceptions import HTTPError
-from yarl import URL
-
 from redbox_app.redbox_core.client import CoreApiClient
 from redbox_app.redbox_core.models import (
     ChatHistory,
@@ -23,6 +20,8 @@ from redbox_app.redbox_core.models import (
     ProcessingStatusEnum,
     User,
 )
+from requests.exceptions import HTTPError
+from yarl import URL
 
 logger = logging.getLogger(__name__)
 core_api = CoreApiClient(host=settings.CORE_API_HOST, port=settings.CORE_API_PORT)


### PR DESCRIPTION
## Context

Chat messages are currently not ordered

## Changes proposed in this pull request

- Added an `order_by("created_at")` to messages

## Guidance to review

- Start a new chat and send a load of messages, then refresh the page, the order should remain

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
