### PR TITLE
Restore feedback link

### DIFF
--- a/django_app/redbox_app/templates/base.html
+++ b/django_app/redbox_app/templates/base.html
@@ -139,7 +139,7 @@
             </li>
           </ul>
           <div class="govuk-footer__meta-custom">
-            This is a new service – your <a class="govuk-link" href="#feedback">feedback</a> will help us to improve it.
+            This is a new service – your <a class="govuk-link" href="https://www.smartsurvey.co.uk/s/EOWJ04/">feedback</a> will help us to improve it.
           </div>
           <svg
             aria-hidden="true"


### PR DESCRIPTION
## Context

Re-adding the correct URL to the feedback link in the footer. Looks like it was accidentally removed in a previous merge / when resolving conflicts.


## Guidance to review

Check the feedback link in the footer takes you through to the feedback form.
