### PR TITLE
Bugfix/broken documents page test

### DIFF
--- a/django_app/tests_playwright/pages.py
+++ b/django_app/tests_playwright/pages.py
@@ -151,7 +151,7 @@ class DocumentsPage(SignedInBasePage):
 
     def get_all_document_rows(self) -> list[DocumentRow]:
         cell_texts = self.page.get_by_role("cell").all_inner_texts()
-        return [DocumentRow(filename, status) for filename, status, action in batched(cell_texts, 3)]
+        return [DocumentRow(filename, status) for filename, uploaded_at, status, action in batched(cell_texts, 4)]
 
 
 class DocumentUploadPage(SignedInBasePage):

--- a/django_app/tests_playwright/test_demo.py
+++ b/django_app/tests_playwright/test_demo.py
@@ -1,7 +1,0 @@
-from _settings import BASE_URL
-from playwright.sync_api import Page, expect
-
-
-def test_has_title(page: Page):
-    page.goto(str(BASE_URL))
-    expect(page.get_by_text("Redbox Copilot")).to_be_visible()


### PR DESCRIPTION
## Context

Due to a couple of different PRs being merged at the same time, we have a broken E2E test - due to the addition of an extra column on the documents table.


## Changes proposed in this pull request

* Update the test
* Remove the demo Playwright test to keep things tidy


## Guidance to review

* Check the playwright tests run
* Check the code change looks okay
