### PR TITLE
bugfix/catch-email-error

### DIFF
--- a/django_app/redbox_app/redbox_core/auth_views.py
+++ b/django_app/redbox_app/redbox_core/auth_views.py
@@ -1,4 +1,5 @@
 import logging
+from smtplib import SMTPException
 
 from django.contrib.auth import logout
 from django.http import HttpRequest
@@ -26,7 +27,7 @@ def sign_in_view(request: HttpRequest):
                 email_handler.send_magic_link_email(full_link, email)
             except models.User.DoesNotExist as e:
                 logger.debug("User with email %s not found", email, exc_info=e)
-            except HTTPError as e:
+            except SMTPException as e:
                 logger.exception("failed to send link to %s", email, exc_info=e)
 
             return redirect("sign-in-link-sent")

--- a/django_app/redbox_app/redbox_core/auth_views.py
+++ b/django_app/redbox_app/redbox_core/auth_views.py
@@ -7,7 +7,6 @@ from django.shortcuts import redirect, render
 from magic_link.models import MagicLink
 from redbox_app.redbox_core import email_handler, models
 from redbox_app.redbox_core.forms import SignInForm
-from requests import HTTPError
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Context

As a user I want email errors to be caught and logged

## Changes proposed in this pull request

* the http exception has been replace with an smtp one as per https://docs.djangoproject.com/en/5.0/topics/email/#send-mail

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
