### PR TITLE
Redirect users from sign in link to the documents page

### DIFF
--- a/django_app/redbox_app/redbox_core/auth_views.py
+++ b/django_app/redbox_app/redbox_core/auth_views.py
@@ -21,7 +21,7 @@ def sign_in_view(request: HttpRequest):
 
             try:
                 user = models.User.objects.get(email=email)
-                link = MagicLink.objects.create(user=user, redirect_to="/")
+                link = MagicLink.objects.create(user=user, redirect_to="/documents")
                 full_link = request.build_absolute_uri(link.get_absolute_url())
                 email_handler.send_magic_link_email(full_link, email)
             except models.User.DoesNotExist as e:

--- a/django_app/tests_playwright/pages.py
+++ b/django_app/tests_playwright/pages.py
@@ -140,9 +140,9 @@ class SignInConfirmationPage(BasePage):
     def get_expected_page_title(self) -> str:
         return "Sign in - confirmation - Redbox Copilot"
 
-    def navigate_to_home_page(self) -> "HomePage":
+    def navigate_to_documents_page(self) -> "DocumentsPage":
         self.page.get_by_role("button", name="Sign in", exact=True).click()
-        return HomePage(self.page)
+        return DocumentsPage(self.page)
 
 
 class HomePage(SignedInBasePage):

--- a/django_app/tests_playwright/test_journey.py
+++ b/django_app/tests_playwright/test_journey.py
@@ -27,10 +27,9 @@ def test_user_journey(page: Page):
     # Use magic link
     magic_link = get_magic_link(EMAIL_ADDRESS, DJANGO_ROOT)
     sign_in_confirmation_page = SignInConfirmationPage(page, magic_link)
-    home_page = sign_in_confirmation_page.navigate_to_home_page()
 
     # Documents page
-    documents_page = home_page.navigate_to_documents()
+    documents_page = sign_in_confirmation_page.navigate_to_documents_page()
     document_upload_page = documents_page.navigate_to_upload()
 
     # Upload a file


### PR DESCRIPTION
## Context

There are a number of changes to the sign in flow suggested here: https://technologyprogramme.atlassian.net/browse/REDBOX-272 . One of these is to direct users from the magic link page to the documents page. 

## Changes proposed in this pull request
On clicking the 'Sign in' button on the magic link page, users are directed to /documents rather than the homepage. Also updates the relevant playwright tests.

## Guidance to review
Run this locally, log out then in again; check the user flow.
Run the playwright tests to see if they work. 

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-272

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
