### PR TITLE
Update homepage and sign-in content

### DIFF
--- a/django_app/frontend/style.scss
+++ b/django_app/frontend/style.scss
@@ -33,8 +33,8 @@ body {
 .iai-banner {
   background-color: $redbox-red;
   color: white;
-  padding-bottom: 2rem;
-  padding-top: 3rem;
+  padding-bottom: 3rem;
+  padding-top: 2.75rem;
 }
 .iai-banner * {
   color: white;
@@ -45,6 +45,11 @@ body {
 .iai-banner .govuk-link:focus {
   background-color: white;
   color: black;
+}
+.iai-banner__links {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
 }
 
 

--- a/django_app/redbox_app/templates/homepage.html
+++ b/django_app/redbox_app/templates/homepage.html
@@ -1,5 +1,6 @@
 {% set pageTitle = "" %}
 {% extends "base.html" %}
+{% from "macros/govuk-button.html" import govukButton %}
 
 {% block content %}
 
@@ -7,11 +8,18 @@
     <div class="govuk-width-container">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
-                <h1 class="govuk-heading-xl">Ask any question of documents in your Redbox</h1>
-                <p class="govuk-body-l">Use Artificial Intelligence (AI) to get insights from your personal document set. You can use up to, and including, {{ security }} documents.</p>
-                {% if not request.user.is_authenticated %}
-                <p class="govuk-body">If you have an account, please <a class="govuk-link" href="{{url('sign-in')}}">sign in</a> to get started</p>
-                {% endif %}
+                <h1 class="govuk-heading-xl govuk-!-margin-bottom-7">Ask any question of documents in your Redbox</h1>
+                <p class="govuk-body-l govuk-!-margin-bottom-7">Use Artificial Intelligence (AI) to get insights from your personal document set. You can use up to, and including, {{ security }} documents.</p>
+                <div class="iai-banner__links">
+                    {% if not request.user.is_authenticated %}
+                        {{ govukButton(
+                            text="Sign in",
+                            href=url('sign-in'),
+                            classes="govuk-button--secondary govuk-!-margin-bottom-0"
+                        ) }}
+                        <span class="govuk-body govuk-!-margin-bottom-0">or <a class="govuk-link" href="https://docs.google.com/forms/d/e/1FAIpQLScNnl2vhazXDdZDpa9_11QYuaGPuNKGnelJC5uWJoEPtuW9zg/viewform">register your interest</a> to use Redbox</span>
+                    {% endif %}
+                </div>
             </div>
         </div>
     </div>

--- a/django_app/redbox_app/templates/magic_link/logmein.html
+++ b/django_app/redbox_app/templates/magic_link/logmein.html
@@ -9,12 +9,12 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-l">Sign in to Redbox Copilot</h1>
+      <h1 class="govuk-heading-l">Welcome to your Redbox</h1>
 
       <form method="POST" action="{{ link.get_absolute_url() }}">
         {{ csrf_input }}
 
-        {{ govukButton(text="Sign in") }}
+        {{ govukButton(text="Start") }}
 
       </form>
     

--- a/django_app/tests_playwright/pages.py
+++ b/django_app/tests_playwright/pages.py
@@ -141,7 +141,7 @@ class SignInConfirmationPage(BasePage):
         return "Sign in - confirmation - Redbox Copilot"
 
     def navigate_to_home_page(self) -> "HomePage":
-        self.page.get_by_role("button", name="Sign in", exact=True).click()
+        self.page.get_by_role("button", name="Start", exact=True).click()
         return HomePage(self.page)
 
 

--- a/redbox/llm/prompts/chat.py
+++ b/redbox/llm/prompts/chat.py
@@ -23,9 +23,11 @@ If a user asks for bullet points you MUST give bullet points. \
 If the user asks for a specific number or range of bullet points you MUST give that number of bullet points. \
 For example
 QUESTION: Please give me 6-8 bullet points on tigers
-FINAL ANSWER: - Tigers are orange. \n- Tigers are big. \n- Tigers are scary. \n- Tigers are cool. \n- Tigers are cats. -\n Tigers are animals. \
+FINAL ANSWER: - Tigers are orange. \n- Tigers are big. \n- Tigers are scary. \n- Tigers are cool. \n- Tigers are \
+cats. -\n Tigers are animals. \
 
-If the number of bullet points a user asks for is not supported by the amount of information that you have, then say so, else give what the user asks for. \
+If the number of bullet points a user asks for is not supported by the amount of information that you have, then \
+say so, else give what the user asks for. \
 
 At the end of your response add a "Sources:" section with the documents you used. \
 DO NOT reference the source documents in your response. Only cite at the end. \
@@ -45,9 +47,7 @@ QUESTION: {question}
 =========
 FINAL ANSWER:"""
 
-WITH_SOURCES_PROMPT = PromptTemplate.from_template(
-    _core_redbox_prompt + _with_sources_template
-)
+WITH_SOURCES_PROMPT = PromptTemplate.from_template(_core_redbox_prompt + _with_sources_template)
 
 _stuff_document_template = "<Doc{parent_doc_uuid}>{page_content}</Doc{parent_doc_uuid}>"
 


### PR DESCRIPTION
## Context

Making content changes to the homepage and magic-link confirmation pages, to help make the sign-in journey clearer.


## Changes proposed in this pull request

* The home-page for signed-out users now looks like this:
![image](https://github.com/i-dot-ai/redbox-copilot/assets/1634605/07265020-615b-49f9-9689-fcc101043d2a)

* The page (after clicking the magic link) now looks like this:
![image](https://github.com/i-dot-ai/redbox-copilot/assets/1634605/960ba383-a8c5-4fba-ba4a-fdaec17daed8)


## Things to check

- [ ] The button and link works on the homepage
- [ ] Both pages look as per the screenshots
- [ ] Tests pass
