### PR TITLE
Move Plausible declaration

### DIFF
--- a/django_app/frontend/js/chats/feedback.js
+++ b/django_app/frontend/js/chats/feedback.js
@@ -1,8 +1,5 @@
 // @ts-check
 
-let plausible = /** @type {any} */ (window).plausible;
-
-
 class FeedbackButtons extends HTMLElement {
 
     connectedCallback() {
@@ -32,7 +29,9 @@ class FeedbackButtons extends HTMLElement {
                 } else {
                     this.dataset.status = response;
                 }
+
                 // send feedback to Plausible
+                let plausible = /** @type {any} */ (window).plausible;
                 if (this.dataset.status && typeof(plausible) !== 'undefined') {
                     plausible(`Feedback-button-thumbs-${this.dataset.status}`);
                 }


### PR DESCRIPTION
## Context

Plausible was being used before the Plausible script had loaded. Moving this one line fixes that.


## Changes proposed in this pull request

Just moving one line to inside the relevant event handler.


## Guidance to review

This isn't an easy one to test until it's on dev, so just check the change looks sensible. If you wanted to, you could set Plausible to load locally and check a request is being made.