### PR TITLE
Add mlflow evaluation notebook [first draft]

### DIFF
--- a/notebooks/evaluation/mlflow_eval_with_testset.ipynb
+++ b/notebooks/evaluation/mlflow_eval_with_testset.ipynb
@@ -1,0 +1,277 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MLFlow test\n",
+    "This is a trial of mlflow RAG evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # These packages may need to be installed via 'pip' or 'poetry add' \n",
+    "# !pip install chromadb mlflow textstat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import mlflow\n",
+    "\n",
+    "from langchain.chains import RetrievalQA\n",
+    "from langchain.document_loaders import PyPDFLoader\n",
+    "from langchain.text_splitter import CharacterTextSplitter\n",
+    "from langchain.vectorstores import Chroma\n",
+    "from langchain_openai import OpenAI, OpenAIEmbeddings\n",
+    "from mlflow.metrics.genai import relevance, faithfulness\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1. Load PDF, chunk, embed and store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = PyPDFLoader(\"/Users/*/Documents/test_files/Science-Trust-and-Policy-report_TEST.pdf\")\n",
+    "\n",
+    "documents = loader.load()\n",
+    "text_splitter = CharacterTextSplitter(chunk_size=500, chunk_overlap=0)\n",
+    "texts = text_splitter.split_documents(documents)\n",
+    "\n",
+    "embeddings = OpenAIEmbeddings()\n",
+    "docsearch = Chroma.from_documents(texts, embeddings)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2. Define a function to get a question, retrieve a chunk and append an answer from the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qa = RetrievalQA.from_chain_type(\n",
+    "    llm=OpenAI(temperature=0),\n",
+    "    chain_type=\"stuff\",\n",
+    "    retriever=docsearch.as_retriever(),\n",
+    "    return_source_documents=True,\n",
+    ")\n",
+    "\n",
+    "def model(input_df):\n",
+    "    answer = []\n",
+    "    for index, row in input_df.iterrows():\n",
+    "        answer.append(qa(row[\"question\"]))\n",
+    "        \n",
+    "    return answer\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3. Load test dataset derived from PDF at step 1\n",
+    "This dataset has been shorted and filtered for cost purposes. All you need are questions and ground truthed answers. These could be derived from humans or an LLM e.g. RAGAS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eval_df = pd.read_excel('/Users/*/Documents/test_files/testset.xlsx')\n",
+    "eval_df = eval_df[eval_df.document == 'stp']\n",
+    "eval_df['ground_truth'] = eval_df['answer']\n",
+    "eval_df = eval_df[['question', 'ground_truth']].reset_index(drop=True)\n",
+    "eval_df = eval_df.iloc[:2]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4. Define additional metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "faithfulness_metric = faithfulness(model=\"openai:/gpt-3.5-turbo\")\n",
+    "relevance_metric = relevance(model=\"openai:/gpt-3.5-turbo\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5. Run experiment and log results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mlflow.set_experiment('test')\n",
+    "\n",
+    "results = mlflow.evaluate(\n",
+    "    model,\n",
+    "    data=eval_df,\n",
+    "    model_type=\"question-answering\",\n",
+    "    evaluators=\"default\",\n",
+    "    predictions=\"result\",\n",
+    "    targets='ground_truth',\n",
+    "    extra_metrics=[faithfulness_metric, relevance_metric],\n",
+    "    evaluator_config={\n",
+    "        \"col_mapping\": {\n",
+    "        \"inputs\": \"question\",\n",
+    "        \"context\": \"source_documents\",\n",
+    "        },\n",
+    "        \"system_prompt\": \"Provide an answer in 3 sentences based on the context.\",\n",
+    "        \"k\": 1 \n",
+    "    },\n",
+    ")\n",
+    "print(results.metrics)\n",
+    "display(results.tables[\"eval_results_table\"])\n",
+    "\n",
+    "mlflow.end_run()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6. Save results as CSV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results.tables[\"eval_results_table\"].to_csv('/Users/*/Documents/code/redbox-copilot/notebooks/evaluation/data/evaluation_files/test_1.csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Misc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # mlflow.set_experiment('test')\n",
+    "\n",
+    "# with mlflow.start_run() as run:\n",
+    "#     system_prompt = \"Answer the following question in two sentences\"\n",
+    "#     basic_qa_model = mlflow.openai.log_model(\n",
+    "#         model=\"gpt-3.5-turbo\",\n",
+    "#         task=openai.chat.completions,\n",
+    "#         artifact_path=\"model\",\n",
+    "#         messages=[\n",
+    "#             {\"role\": \"system\", \"content\": system_prompt},\n",
+    "#             {\"role\": \"user\", \"content\": \"{question}\"},\n",
+    "#         ],\n",
+    "#     )\n",
+    "#     results = mlflow.evaluate(\n",
+    "#         basic_qa_model.model_uri,\n",
+    "#         eval_df,\n",
+    "#         targets=\"ground_truth\",  # specify which column corresponds to the expected output\n",
+    "#         model_type=\"question-answering\",  # model type indicates which metrics are relevant for this task\n",
+    "#         evaluators=\"default\",\n",
+    "#         extra_metrics=[faithfulness_metric, relevance_metric],\n",
+    "\n",
+    "#     )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# mlflow.set_experiment('new')\n",
+    "\n",
+    "# system_prompt = \"Answer the following question in two sentences\"\n",
+    "# basic_qa_model = mlflow.openai.log_model(\n",
+    "#     model=\"gpt-3.5-turbo\",\n",
+    "#     task=openai.chat.completions,\n",
+    "#     artifact_path=\"model\",\n",
+    "#     messages=[\n",
+    "#         {\"role\": \"system\", \"content\": system_prompt},\n",
+    "#         {\"role\": \"user\", \"content\": \"{question}\"},\n",
+    "#     ],\n",
+    "# )\n",
+    "\n",
+    "# with mlflow.start_run() as run:\n",
+    "#     results = mlflow.evaluate(\n",
+    "#         basic_qa_model.model_uri,\n",
+    "#         eval_df,\n",
+    "#         targets=\"ground_truth\",  # specify which column corresponds to the expected output\n",
+    "#         model_type=\"question-answering\",  # model type indicates which metrics are relevant for this task\n",
+    "#         # extra_metrics=[faithfulness_metric, relevance_metric],\n",
+    "#     )\n",
+    "# results.metrics\n",
+    "\n",
+    "# mlflow.end_run()\n",
+    "# # print(results.metrics)\n",
+    "# # display(results.tables[\"eval_results_table\"])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Context

Testing feasibility of MLflow for evaluating Redbox as logging of results will be easier and more robust.

## Changes proposed in this pull request

Added a notebook that uses MLflow evaluation with a test dataset generated by humans or generated by an LLM e.g. RAGAS.

## Guidance to review

Check if the notebook runs locally on your machine.

## Relevant links

https://mlflow.org/docs/latest/model-evaluation/index.html
https://mlflow.org/docs/latest/llms/llm-evaluate/notebooks/rag-evaluation.html

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
