### PR TITLE
bugfix/get-openai-working-again

### DIFF
--- a/core_api/src/routes/chat.py
+++ b/core_api/src/routes/chat.py
@@ -26,7 +26,7 @@ from redbox.llm.prompts.chat import (
 )
 from redbox.model_db import MODEL_PATH
 from redbox.models import EmbeddingModelInfo, Settings
-from redbox.models.chat import ChatMessage, ChatRequest, ChatResponse, SourceDocument
+from redbox.models.chat import ChatRequest, ChatResponse, SourceDocument
 
 # === Logging ===
 
@@ -149,7 +149,7 @@ def simple_chat(chat_request: ChatRequest, _user_uuid: Annotated[UUID, Depends(g
     messages = chat_prompt.format_messages()
 
     response = llm(messages)
-    chat_response:ChatResponse = ChatResponse(output_text=response.content)
+    chat_response: ChatResponse = ChatResponse(output_text=response.content)
     return chat_response
 
 

--- a/core_api/src/routes/chat.py
+++ b/core_api/src/routes/chat.py
@@ -73,7 +73,6 @@ embedding_model_info = populate_embedding_model_info()
 if env.openai_api_key is not None:
     log.info("Creating OpenAI LLM Client")
     llm = ChatLiteLLM(
-        model=env.openai_model,
         streaming=True,
         openai_key=env.openai_api_key,
     )
@@ -88,7 +87,7 @@ elif env.azure_openai_api_key is not None:
     os.environ["OPENAI_API_VERSION"] = env.openai_api_version
 
     llm = ChatLiteLLM(
-        model=env.openai_model,
+        model=env.azure_openai_model,
         streaming=True,
         azure_key=env.azure_openai_api_key,
         api_version=env.openai_api_version,

--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -26,8 +26,8 @@ locals {
     "DEBUG" : true,
     "AWS_REGION" : var.region,
     "FROM_EMAIL" : var.from_email,
-    "OPENAI_MODEL": var.openai_model,
     "OPENAI_API_VERSION": var.openai_api_version,
+    "AZURE_OPENAI_MODEL": var.azure_openai_model,
     "AZURE_OPENAI_ENDPOINT": var.azure_openai_endpoint,
     "AZURE_OPENAI_API_KEY": var.azure_openai_api_key
     "GOVUK_NOTIFY_PLAIN_EMAIL_TEMPLATE_ID" : var.govuk_notify_plain_email_template_id

--- a/infrastructure/aws/variables.tf
+++ b/infrastructure/aws/variables.tf
@@ -87,7 +87,7 @@ variable "internal_ips" {
   description = "IP's of No10 and CO"
 }
 
-variable "openai_model" {
+variable "azure_openai_model" {
   type        = string
   default     = "gpt-3.5-turbo"
   description = "OPENAI model to use"

--- a/redbox/models/settings.py
+++ b/redbox/models/settings.py
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
     azure_openai_endpoint: str | None = None
 
     openai_api_version: str = "2023-12-01-preview"
-    openai_model: str = "azure/gpt-35-turbo-16k"
+    azure_openai_model: str = "azure/gpt-35-turbo-16k"
 
     partition_strategy: Literal["auto", "fast", "ocr_only", "hi_res"] = "fast"
 


### PR DESCRIPTION
## Context

As a user I want to be able to use OpenAI as well as Azure

## Changes proposed in this pull request

Previously we were passing `OPENAI_MODEL` into `ChatLiteLLM` (which by default is `azure/gpt-35-turbo-16k`), this is only required for azure so this envvar has been renamed `AZURE_OPENAI_MODEL`

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests
