### PR TITLE
Send message on enter key press

### DIFF
--- a/django_app/frontend/js/chats/fallback.js
+++ b/django_app/frontend/js/chats/fallback.js
@@ -14,7 +14,7 @@
     }
 
     // show loading message when button is clicked
-    document.querySelector('.js-send-btn')?.addEventListener('click', (evt) => {
+    document.querySelector('.js-message-input')?.addEventListener('submit', (evt) => {      
         let textBox = /** @type {HTMLInputElement} */ (document.querySelector('.js-user-text'));
         if (!textBox.value) {
             return;

--- a/django_app/frontend/js/chats/fallback.js
+++ b/django_app/frontend/js/chats/fallback.js
@@ -16,7 +16,7 @@
     // show loading message when button is clicked
     document.querySelector('.js-message-input')?.addEventListener('submit', (evt) => {      
         let textBox = /** @type {HTMLInputElement} */ (document.querySelector('.js-user-text'));
-        if (!textBox.value) {
+        if (!textBox.value.trim()) {
             return;
         }
         const loadingMessage = /** @type {HTMLElement} */ (document.querySelector('.js-response-loading'));

--- a/django_app/frontend/js/chats/message-input.js
+++ b/django_app/frontend/js/chats/message-input.js
@@ -9,7 +9,7 @@ class MessageInput extends HTMLElement {
         textarea?.addEventListener('keypress', (evt) => {
             if (evt.key === 'Enter' && !evt.shiftKey) {
                 evt.preventDefault();
-                if (textarea.value) {
+                if (textarea.value.trim()) {
                     this.closest('form')?.requestSubmit();
                 }
             }

--- a/django_app/frontend/js/chats/message-input.js
+++ b/django_app/frontend/js/chats/message-input.js
@@ -1,0 +1,21 @@
+// @ts-check
+
+class MessageInput extends HTMLElement {
+
+    connectedCallback() {
+
+        // Submit form on enter-key press (providing shift isn't being pressed)
+        const textarea = this.querySelector('textarea');
+        textarea?.addEventListener('keypress', (evt) => {
+            if (evt.key === 'Enter' && !evt.shiftKey) {
+                evt.preventDefault();
+                if (textarea.value) {
+                    this.closest('form')?.requestSubmit();
+                }
+            }
+        });
+
+    }
+  
+}
+customElements.define('message-input', MessageInput);

--- a/django_app/frontend/js/chats/streaming.js
+++ b/django_app/frontend/js/chats/streaming.js
@@ -133,13 +133,13 @@ class ChatController extends HTMLElement {
 
     connectedCallback() {
 
-        const sendButton = this.querySelector('.js-send-btn');
+        const messageForm = this.querySelector('.js-message-input');
         const textArea = /** @type {HTMLInputElement | null} */ (this.querySelector('.js-user-text'));
         const messageContainer = this.querySelector('.js-message-container');
         const insertPosition = this.querySelector('.js-response-feedback');
         const feedbackButtons = /** @type {HTMLElement | null} */ (this.querySelector('feedback-buttons'));
 
-        sendButton?.addEventListener('click', (evt) => {
+        messageForm?.addEventListener('submit', (evt) => {
             
             evt.preventDefault();
             const userText = textArea?.value;

--- a/django_app/frontend/js/chats/streaming.js
+++ b/django_app/frontend/js/chats/streaming.js
@@ -142,7 +142,7 @@ class ChatController extends HTMLElement {
         messageForm?.addEventListener('submit', (evt) => {
             
             evt.preventDefault();
-            const userText = textArea?.value;
+            const userText = textArea?.value.trim();
             if (!textArea || !userText) {
                 return;
             }

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -79,7 +79,7 @@
 
       </div>
 
-      <form class="iai-new-message js-send-message" action="/post-message/" method="post">
+      <form class="iai-new-message js-message-input" action="/post-message/" method="post">
 
         <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}"/>
         {% if chat_id %}<input type="hidden" name="session-id" value="{{ chat_id }}"/>{% endif %}
@@ -88,22 +88,23 @@
           <label class="govuk-label" for="message">
             Write a message
           </label>
-          <textarea class="govuk-textarea js-user-text" id="message" name="message" rows="5" required></textarea>
+          <message-input>
+            <textarea class="govuk-textarea js-user-text" id="message" name="message" rows="5" required></textarea>
+          </message-input>
         </div>
 
-          <button type="submit" class="govuk-button js-send-btn" {% if not streaming.in_use %}data-prevent-double-click="true"{% endif %} data-module="govuk-button">
-            Send
-          </button>
+        <button type="submit" class="govuk-button" {% if not streaming.in_use %}data-prevent-double-click="true"{% endif %} data-module="govuk-button">
+          Send
+        </button>
 
-        </form>
+      </form>
 
-        <div class="iai-response-loading js-response-loading govuk-!-margin-top-1" tabindex="-1">
-          <img class="iai-response-loading__spinner" src="{{ static('images/spinner.gif') }}" alt=""/>
-          <p class="iai-response-loading__text govuk-body govuk-!-margin-bottom-0 govuk-!-margin-left-1">Response loading...</p>
-        </div>
+      <div class="iai-response-loading js-response-loading govuk-!-margin-top-1" tabindex="-1">
+        <img class="iai-response-loading__spinner" src="{{ static('images/spinner.gif') }}" alt=""/>
+        <p class="iai-response-loading__text govuk-body govuk-!-margin-bottom-0 govuk-!-margin-left-1">Response loading...</p>
+      </div>
 
-      </chat-controller>
-    </div>
+    </chat-controller>
 
   </div>
 </div>
@@ -114,10 +115,12 @@
   {% compress js %}
     <script src="{{ static('js/chats/markdown.js') }}"></script>
     <script src="{{ static('js/chats/feedback.js') }}"></script>
+    <script src="{{ static('js/chats/message-input.js') }}"></script>
   {% endcompress %}
 {% else %}
   <script src="{{ static('js/chats/markdown.js') }}"></script>
   <script src="{{ static('js/chats/feedback.js') }}"></script>
+  <script src="{{ static('js/chats/message-input.js') }}"></script>
 {% endif %}
 
 


### PR DESCRIPTION
## Context

From testing so far, users expect to send a message on pressing the enter key.


## Changes proposed in this pull request

* When in the textarea, pressing enter sends the message
* When in the textarea, pressing enter+shift goes to a new line (without sending the message)
* Prevent sending messages with just spaces by calling `.trim()`


## Things to check

That this works with and without streaming enabled
