### PR TITLE
Add tests for feedback buttons

### DIFF
--- a/django_app/tests_playwright/test_chats.py
+++ b/django_app/tests_playwright/test_chats.py
@@ -1,0 +1,26 @@
+from _signin import sign_in
+from playwright.sync_api import Page
+from tests_playwright.pages import ChatsPage, FeedbackType
+
+
+def test_response_feedback(page: Page):
+    home_page = sign_in(page)
+
+    chats_page: ChatsPage = home_page.navigate_to_chats()
+    chats_page.write_message = "This is a test chat"
+    chats_page = chats_page.send()
+
+    assert not chats_page.check_feedback_prompt_visible(FeedbackType.HELPFUL)
+    assert not chats_page.check_feedback_prompt_visible(FeedbackType.NOT_HELPFUL)
+
+    chats_page.give_feedback(FeedbackType.HELPFUL)
+    assert chats_page.check_feedback_prompt_visible(FeedbackType.HELPFUL)
+    assert not chats_page.check_feedback_prompt_visible(FeedbackType.NOT_HELPFUL)
+
+    chats_page.give_feedback(FeedbackType.NOT_HELPFUL)
+    assert chats_page.check_feedback_prompt_visible(FeedbackType.NOT_HELPFUL)
+    assert not chats_page.check_feedback_prompt_visible(FeedbackType.HELPFUL)
+
+    chats_page.give_feedback(FeedbackType.NOT_HELPFUL)
+    assert not chats_page.check_feedback_prompt_visible(FeedbackType.HELPFUL)
+    assert not chats_page.check_feedback_prompt_visible(FeedbackType.NOT_HELPFUL)


### PR DESCRIPTION
## Context

Adding tests for the feedback buttons functionality


## Changes proposed in this pull request

* Building new tests in `test_chats.py`
* Updating `_signin.py`
* Bonus: Tidying up the `check_a11y` function - cleaner code and better reporting


## Guidance to review

* Check the tests pass
* I haven't put too much thought into how best to structure files within the Playwright tests folder for now, as @brunns has  some cool plans around that, which will be done as a separate PR