### PR TITLE
Build delete-doc E2E test

### DIFF
--- a/django_app/tests_playwright/pages.py
+++ b/django_app/tests_playwright/pages.py
@@ -155,6 +155,10 @@ class DocumentRow(NamedTuple):
 class DocumentsPage(SignedInBasePage):
     def get_expected_page_title(self) -> str:
         return "Documents - Redbox Copilot"
+    
+    def delete_latest_document(self) -> "DocumentDeletePage":
+        self.page.get_by_role("button", name="Remove").first.click()
+        return DocumentDeletePage(self.page)
 
     def navigate_to_upload(self) -> "DocumentUploadPage":
         self.page.get_by_role("button", name="Add document").click()
@@ -163,6 +167,15 @@ class DocumentsPage(SignedInBasePage):
     def get_all_document_rows(self) -> list[DocumentRow]:
         cell_texts = self.page.get_by_role("cell").all_inner_texts()
         return [DocumentRow(filename, status) for filename, uploaded_at, status, action in batched(cell_texts, 4)]
+
+
+class DocumentDeletePage(SignedInBasePage):
+    def get_expected_page_title(self) -> str:
+        return "Remove document - Redbox Copilot"
+    
+    def confirm_deletion(self) -> "DocumentsPage":
+        self.page.get_by_role("button", name="Remove").click()
+        return DocumentsPage(self.page)
 
 
 class DocumentUploadPage(SignedInBasePage):

--- a/django_app/tests_playwright/test_journey.py
+++ b/django_app/tests_playwright/test_journey.py
@@ -30,15 +30,23 @@ def test_user_journey(page: Page):
 
     # Documents page
     documents_page = sign_in_confirmation_page.navigate_to_documents_page()
-    document_upload_page = documents_page.navigate_to_upload()
+    document_rows = documents_page.get_all_document_rows()
+    original_docs_count = len(document_rows)
 
     # Upload a file
+    document_upload_page = documents_page.navigate_to_upload()
     upload_file = DJANGO_ROOT / "files" / "RiskTriggersReport361.pdf"
     documents_page = document_upload_page.upload_document(upload_file)
-
     document_rows = documents_page.get_all_document_rows()
     logger.debug("document_rows: %s", document_rows)
     assert any(row.filename == upload_file.name for row in document_rows)
+    assert len(document_rows) == original_docs_count + 1
+
+    # Delete a file
+    document_delete_page = documents_page.delete_latest_document()
+    documents_page = document_delete_page.confirm_deletion()
+    document_rows = documents_page.get_all_document_rows()
+    assert len(document_rows) == original_docs_count
 
     # Chats page
     chats_page = documents_page.navigate_to_chats()


### PR DESCRIPTION
## Context

Adding an E2E test for deleting a document. A double benefit of testing this part of the journey, and tidying up having duplicate documents after running the tests locally.


## Changes proposed in this pull request

* Add a delete-doc test
* Make the add-doc test more robust by checking quantity of docs (as well as the presence of the filename)


## Link to Jira ticket

https://technologyprogramme.atlassian.net/browse/REDBOX-288?atlOrigin=eyJpIjoiMDVkYzlkMjI4YTdiNGE4MGEwYjcxMWJhMjMzY2M1NjAiLCJwIjoiaiJ9


## Things to check

* That the tests pass
* That the code looks sensible
