### PR TITLE
delete expired chats with management command

### DIFF
--- a/django_app/redbox_app/redbox_core/management/commands/delete_expired_data.py
+++ b/django_app/redbox_app/redbox_core/management/commands/delete_expired_data.py
@@ -54,21 +54,10 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS(f"Successfully deleted {counter} file objects"))
 
         self.stdout.write(self.style.NOTICE(f"Deleting chats expired before {cutoff_date}"))
-        counter = 0
-        message_counter = 0
-
         chats_to_delete = ChatHistory.objects.annotate(last_modified_at=Max("chatmessage__modified_at")).filter(
             last_modified_at__lt=cutoff_date
         )
+        counter = chats_to_delete.count()
+        chats_to_delete.delete()
 
-        for chat_history in chats_to_delete:
-            logger.debug("Deleting %s and linked messages", chat_history)
-            message_counter += chat_history.chatmessage_set.count()
-            chat_history.delete()
-            counter += 1
-
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"Successfully deleted {counter} ChatHistory objects and {message_counter} related ChatMessages"
-            )
-        )
+        self.stdout.write(self.style.SUCCESS(f"Successfully deleted {counter} ChatHistory objects"))

--- a/django_app/tests/management/test_commands.py
+++ b/django_app/tests/management/test_commands.py
@@ -9,8 +9,9 @@ from botocore.exceptions import UnknownClientMethodError
 from django.conf import settings
 from django.core.management import CommandError, call_command
 from django.utils import timezone
+from freezegun import freeze_time
 from magic_link.models import MagicLink
-from redbox_app.redbox_core.models import File, StatusEnum, User
+from redbox_app.redbox_core.models import ChatHistory, ChatMessage, ChatRoleEnum, File, StatusEnum, User
 from requests_mock import Mocker
 
 # === show_magiclink_url command tests ===
@@ -78,7 +79,7 @@ EXPIRED_FILE_DATE = timezone.now() - timedelta(seconds=(settings.FILE_EXPIRY_IN_
     ],
 )
 @pytest.mark.django_db()
-def test_delete_expired_data(
+def test_delete_expired_files(
     uploaded_file: File, requests_mock: Mocker, last_referenced: datetime, should_delete: bool
 ):
     # Given
@@ -105,7 +106,7 @@ def test_delete_expired_data(
 
 
 @pytest.mark.django_db()
-def test_delete_expired_data_with_api_error(uploaded_file: File, requests_mock: Mocker):
+def test_delete_expired_files_with_api_error(uploaded_file: File, requests_mock: Mocker):
     # Given
     mock_file = uploaded_file
     mock_file.last_referenced = EXPIRED_FILE_DATE
@@ -126,7 +127,7 @@ def test_delete_expired_data_with_api_error(uploaded_file: File, requests_mock: 
 
 
 @pytest.mark.django_db()
-def test_delete_expired_data_with_s3_error(uploaded_file: File, requests_mock: Mocker):
+def test_delete_expired_files_with_s3_error(uploaded_file: File, requests_mock: Mocker):
     with mock.patch("redbox_app.redbox_core.models.File.delete_from_s3") as s3_mock:
         s3_mock.side_effect = UnknownClientMethodError(method_name="")
 
@@ -150,3 +151,35 @@ def test_delete_expired_data_with_s3_error(uploaded_file: File, requests_mock: M
 
         # Then
         assert File.objects.get(id=mock_file.id).status == StatusEnum.errored
+
+
+@pytest.mark.parametrize(
+    ("msg_1_date", "msg_2_date", "should_delete"),
+    [
+        (EXPIRED_FILE_DATE, EXPIRED_FILE_DATE, True),
+        (EXPIRED_FILE_DATE, timezone.now(), False),
+        (timezone.now(), timezone.now(), False),
+    ],
+)
+@pytest.mark.django_db()
+def test_delete_expired_chats(
+    chat_history: ChatHistory, msg_1_date: datetime, msg_2_date: datetime, should_delete: bool
+):
+    # Given
+    test_chat_history = chat_history
+    with freeze_time(msg_1_date):
+        chat_message_1 = ChatMessage.objects.create(
+            chat_history=test_chat_history, text="A question?", role=ChatRoleEnum.user
+        )
+    with freeze_time(msg_2_date):
+        chat_message_2 = ChatMessage.objects.create(
+            chat_history=test_chat_history, text="A question?", role=ChatRoleEnum.user
+        )
+
+    # When
+    call_command("delete_expired_data")
+
+    # Then
+    assert ChatHistory.objects.filter(id=chat_history.id).exists() != should_delete
+    assert ChatMessage.objects.filter(id=chat_message_1.id).exists() != should_delete
+    assert ChatMessage.objects.filter(id=chat_message_2.id).exists() != should_delete


### PR DESCRIPTION
## Context
Following on from #518, this extends the data deletion management command to remove expired chats and their histories. 

As discussed in [this Slack thread](https://i-dot-ai.slack.com/archives/C05D67P6M34/p1717584257305169), a ChatHistory and its messages are deleted only when all of the messages in the ChatHistory have exceeded the expiry period. 

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
Check the tests have a sensible level of detail. Could change the retention period (FILE_EXPIRY_IN_DAYS) in your local environment and run the command.

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-229

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
