### PR TITLE
Enable multi-file uploads

### DIFF
--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -82,23 +82,23 @@ def upload_view(request):
 
     if request.method == "POST":
         # https://django-storages.readthedocs.io/en/1.13.2/backends/amazon-S3.html
-        try:
-            uploaded_files: list[UploadedFile] = request.FILES.getlist("uploadDoc")
+        
+        uploaded_files: list[UploadedFile] = request.FILES.getlist("uploadDoc")
 
-            for uploaded_file in uploaded_files:
-                file_extension = Path(uploaded_file.name).suffix
-                
-                if uploaded_file.name is None:
-                    errors.append("File has no name")
-                if uploaded_file.content_type is None:
-                    errors.append(f"Error with {uploaded_file.name}: File has no content-type")
-                if uploaded_file.size > MAX_FILE_SIZE:
-                    errors.append(f"Error with {uploaded_file.name}: File is larger than 200MB")
-                if file_extension not in APPROVED_FILE_EXTENSIONS:
-                    errors.append(f"Error with {uploaded_file.name}: File type {file_extension} not supported")
-
-        except MultiValueDictKeyError:
+        if len(uploaded_files) == 0:
             errors.append("No document selected")
+
+        for uploaded_file in uploaded_files:
+            file_extension = Path(uploaded_file.name).suffix
+            
+            if uploaded_file.name is None:
+                errors.append("File has no name")
+            if uploaded_file.content_type is None:
+                errors.append(f"Error with {uploaded_file.name}: File has no content-type")
+            if uploaded_file.size > MAX_FILE_SIZE:
+                errors.append(f"Error with {uploaded_file.name}: File is larger than 200MB")
+            if file_extension not in APPROVED_FILE_EXTENSIONS:
+                errors.append(f"Error with {uploaded_file.name}: File type {file_extension} not supported")
 
         if not errors:
             for uploaded_file in uploaded_files:

--- a/django_app/redbox_app/templates/documents.html
+++ b/django_app/redbox_app/templates/documents.html
@@ -129,7 +129,7 @@
 
       <div class="govuk-button-group">
         {{ govukButton(
-          text="Add document",
+          text="Add documents",
           href=url('upload'),
           classes="iai-button--blue"
         ) }}

--- a/django_app/redbox_app/templates/documents.html
+++ b/django_app/redbox_app/templates/documents.html
@@ -18,6 +18,23 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
       
+      {% if ingest_errors %}
+        <div class="govuk-error-summary" data-module="govuk-error-summary">
+          <div role="alert">
+            <h2 class="govuk-error-summary__title">
+              There was a problem uploading some documents
+            </h2>
+            <div class="govuk-error-summary__body">
+              <ul class="govuk-list govuk-error-summary__list">
+                {% for error in ingest_errors %}
+                  <li>{{ error }}</li>
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+
       <h1 class="govuk-heading-l govuk-!-margin-top-5">Your documents</h1>
 
       <p class="govuk-body-l">Manage documents to use with your Redbox.</p>

--- a/django_app/redbox_app/templates/upload.html
+++ b/django_app/redbox_app/templates/upload.html
@@ -36,7 +36,7 @@
               <span class="govuk-visually-hidden">Error:</span> {{ error }}
             </p>
           {% endfor %}
-          <input class="govuk-file-upload {% if errors.upload_doc %} govuk-file-upload--error{% endif %}" id="upload-doc" name="uploadDoc" type="file" aria-describedby="upload-doc-notification upload-doc-filetypes {% if errors.upload_doc %} file-upload-doc-error{% endif %}">
+          <input class="govuk-file-upload {% if errors.upload_doc %} govuk-file-upload--error{% endif %}" multiple id="upload-doc" name="uploadDoc" type="file" aria-describedby="upload-doc-notification upload-doc-filetypes {% if errors.upload_doc %} file-upload-doc-error{% endif %}">
         </div>
 
         {{ govukButton(text="Upload") }}

--- a/django_app/redbox_app/templates/upload.html
+++ b/django_app/redbox_app/templates/upload.html
@@ -17,11 +17,11 @@
         <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
 
         <div class="govuk-form-group {% if errors.upload_doc %} govuk-form-group--error{% endif %}">
-          <label class="govuk-label" for="upload-doc">
+          <label class="govuk-label" for="upload-docs">
             <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
           </label>
           
-          <div id="upload-doc-notification">
+          <div id="upload-docs-notification">
             {{ govukNotificationBanner(
               title="Important",
               text_list=[
@@ -30,13 +30,13 @@
             ) }}
           </div>
 
-          <p class="govuk-body iai-file-types" id="upload-doc-filetypes">Limit 200MB per file: EML, HTML, JSON, MD, MSG, RST, RTF, TXT, XML, CSV, DOC, DOCX, EPUB, ODT, PDF, PPT, PPTX, TSV, XLSX, HTM</p>
+          <p class="govuk-body iai-file-types" id="upload-docs-filetypes">Limit 200MB per file: EML, HTML, JSON, MD, MSG, RST, RTF, TXT, XML, CSV, DOC, DOCX, EPUB, ODT, PDF, PPT, PPTX, TSV, XLSX, HTM</p>
           {% for error in errors.upload_doc %}
-            <p id="file-upload-doc-error" class="govuk-error-message">
+            <p id="file-upload-docs-error" class="govuk-error-message">
               <span class="govuk-visually-hidden">Error:</span> {{ error }}
             </p>
           {% endfor %}
-          <input class="govuk-file-upload {% if errors.upload_doc %} govuk-file-upload--error{% endif %}" multiple id="upload-doc" name="uploadDoc" type="file" aria-describedby="upload-doc-notification upload-doc-filetypes {% if errors.upload_doc %} file-upload-doc-error{% endif %}">
+          <input class="govuk-file-upload {% if errors.upload_doc %} govuk-file-upload--error{% endif %}" multiple id="upload-docs" name="uploadDocs" type="file" aria-describedby="upload-docs-notification upload-docs-filetypes {% if errors.upload_doc %} file-upload-docs-error{% endif %}">
         </div>
 
         {{ govukButton(text="Upload") }}

--- a/django_app/redbox_app/urls.py
+++ b/django_app/redbox_app/urls.py
@@ -29,7 +29,7 @@ info_urlpatterns = [
 
 file_urlpatterns = [
     path("documents/", views.documents_view, name="documents"),
-    path("upload/", views.upload_view, name="upload"),
+    path("upload/", views.UploadView.as_view(), name="upload"),
     path("remove-doc/<uuid:doc_id>", views.remove_doc_view, name="remove-doc"),
 ]
 

--- a/django_app/tests/test_views.py
+++ b/django_app/tests/test_views.py
@@ -76,7 +76,7 @@ def test_upload_view(alice, client, file_pdf_path: Path, s3_client, requests_moc
     )
 
     with file_pdf_path.open("rb") as f:
-        response = client.post("/upload/", {"uploadDoc": f})
+        response = client.post("/upload/", {"uploadDocs": f})
 
         assert file_exists(s3_client, file_name)
         assert response.status_code == HTTPStatus.FOUND
@@ -106,7 +106,7 @@ def test_document_upload_status(client, alice, file_pdf_path: Path, s3_client, r
     )
 
     with file_pdf_path.open("rb") as f:
-        response = client.post("/upload/", {"uploadDoc": f})
+        response = client.post("/upload/", {"uploadDocs": f})
 
         assert response.status_code == HTTPStatus.FOUND
         assert response.url == "/documents/"
@@ -133,8 +133,8 @@ def test_upload_view_duplicate_files(alice, bob, client, file_pdf_path: Path, s3
     client.force_login(alice)
 
     with file_pdf_path.open("rb") as f:
-        client.post("/upload/", {"uploadDoc": f})
-        response = client.post("/upload/", {"uploadDoc": f})
+        client.post("/upload/", {"uploadDocs": f})
+        response = client.post("/upload/", {"uploadDocs": f})
 
         assert response.status_code == HTTPStatus.FOUND
         assert response.url == "/documents/"
@@ -142,7 +142,7 @@ def test_upload_view_duplicate_files(alice, bob, client, file_pdf_path: Path, s3
         assert count_s3_objects(s3_client) == previous_count + 2
 
         client.force_login(bob)
-        response = client.post("/upload/", {"uploadDoc": f})
+        response = client.post("/upload/", {"uploadDocs": f})
 
         assert response.status_code == HTTPStatus.FOUND
         assert response.url == "/documents/"
@@ -160,7 +160,7 @@ def test_upload_view_bad_data(alice, client, file_py_path: Path, s3_client):
     client.force_login(alice)
 
     with file_py_path.open("rb") as f:
-        response = client.post("/upload/", {"uploadDoc": f})
+        response = client.post("/upload/", {"uploadDocs": f})
 
         assert response.status_code == HTTPStatus.OK
         assert "File type .py not supported" in str(response.content)
@@ -200,7 +200,7 @@ def test_remove_doc_view(client: Client, alice: User, file_pdf_path: Path, s3_cl
 
     with file_pdf_path.open("rb") as f:
         # create file before testing deletion
-        client.post("/upload/", {"uploadDoc": f})
+        client.post("/upload/", {"uploadDocs": f})
         assert file_exists(s3_client, file_name)
         assert count_s3_objects(s3_client) == previous_count + 1
 


### PR DESCRIPTION
## Context

Enabling multi-file uploads to improve the upload journey.


## Changes proposed in this pull request

* Enable multi-file uploads
* State filename with each error message so it's clear what file each error message is related to
* Standard error messages (e.g. incorrect file type) are handled as before, showing on the upload page. This prevents uploading of all files.
* For ingest errors, because some files may have already started the ingest process, the user is taken to the documents page where they can see which files have been uploaded, as well as an error message for any that have failed.
![image](https://github.com/i-dot-ai/redbox-copilot/assets/1634605/b3c4afdc-1e92-4c50-ac9e-67ab458a9c8d)



## Guidance to review

* Test with multiple supported files, to ensure it works as intended
* Test with a mix of supported and unsupported files, to ensure that (a) no files get uploaded, and (b) relevant error messages are displayed
