### PR TITLE
Download Chat Histories

### DIFF
--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -1,4 +1,7 @@
+import csv
+
 from django.contrib import admin
+from django.http import HttpResponse
 
 from . import models
 
@@ -18,9 +21,29 @@ class ChatMessageInline(admin.StackedInline):
 
 
 class ChatHistoryAdmin(admin.ModelAdmin):
+    def export_as_csv(self, request, queryset):  # noqa:ARG002
+        history_field_names = [field.name for field in models.ChatHistory._meta.fields]  # noqa:SLF001
+        message_field_names = [field.name for field in models.ChatMessage._meta.fields]  # noqa:SLF001
+
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = "attachment; filename=chathistory.csv"
+        writer = csv.writer(response)
+
+        writer.writerow(history_field_names + message_field_names)
+        for chat_history in queryset:
+            for chat_message in chat_history.chatmessage_set.all():
+                writer.writerow(
+                    [getattr(chat_history, field) for field in history_field_names]
+                    + [getattr(chat_message, field) for field in message_field_names]
+                )
+
+        return response
+
+    export_as_csv.short_description = "Export Selected"
     inlines = [ChatMessageInline]
     list_display = ["name", "users"]
     list_filter = ["users"]
+    actions = ["export_as_csv"]
 
 
 admin.site.register(models.User, UserResource)


### PR DESCRIPTION
## Context

To help us analyse data from our MVP, it would be helpful to collect user chats to identify common tasks. 

## Changes proposed in this pull request

This adds an action to download Chat History and Message data as a CSV file. The file itself is quite ugly, but what's important is that we can get a data cut quickly.

## Guidance to review

Go to `http://localhost:8090/admin/redbox_core/chathistory/`, select all and choose the action 'Export Selected'

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-311

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
