### PR TITLE
bugfix/order-chat-messages

### DIFF
--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -69,7 +69,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
     @database_sync_to_async
     def get_messages(self, session: ChatHistory) -> list[ChatMessage]:
-        return list(ChatMessage.objects.filter(chat_history=session))
+        return list(ChatMessage.objects.filter(chat_history=session).order_by("-created_at"))
 
     @database_sync_to_async
     def save_message(

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -9,6 +9,8 @@ from redbox_app.redbox_core.models import ChatHistory, ChatMessage, ChatRoleEnum
 from websockets.client import connect
 from yarl import URL
 
+from django_app.redbox_app.redbox_core.models import get_ordered_chat_messages
+
 logger = logging.getLogger(__name__)
 logger.info("WEBSOCKET_SCHEME is: %s", settings.WEBSOCKET_SCHEME)
 
@@ -69,7 +71,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
 
     @database_sync_to_async
     def get_messages(self, session: ChatHistory) -> list[ChatMessage]:
-        return list(ChatMessage.objects.filter(chat_history=session).order_by("-created_at"))
+        return get_ordered_chat_messages(session)
 
     @database_sync_to_async
     def save_message(

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -5,11 +5,9 @@ from types import SimpleNamespace
 from channels.db import database_sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
 from django.conf import settings
-from redbox_app.redbox_core.models import ChatHistory, ChatMessage, ChatRoleEnum, File, User
+from redbox_app.redbox_core.models import ChatHistory, ChatMessage, ChatRoleEnum, File, User, get_ordered_chat_messages
 from websockets.client import connect
 from yarl import URL
-
-from django_app.redbox_app.redbox_core.models import get_ordered_chat_messages
 
 logger = logging.getLogger(__name__)
 logger.info("WEBSOCKET_SCHEME is: %s", settings.WEBSOCKET_SCHEME)

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -153,7 +153,6 @@ class ChatHistory(UUIDPrimaryKeyBase, TimeStampedModel):
     class Meta:
         verbose_name_plural = "Chat history"
 
-
     def __str__(self) -> str:  # pragma: no cover
         return f"{self.name} - {self.users}"
 

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -153,6 +153,7 @@ class ChatHistory(UUIDPrimaryKeyBase, TimeStampedModel):
     class Meta:
         verbose_name_plural = "Chat history"
 
+
     def __str__(self) -> str:  # pragma: no cover
         return f"{self.name} - {self.users}"
 
@@ -175,3 +176,7 @@ class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):
 
     def __str__(self) -> str:  # pragma: no cover
         return f"{self.chat_history} - {self.text} - {self.role}"
+
+
+def get_ordered_chat_messages(session: ChatHistory):
+    return list(ChatMessage.objects.filter(chat_history=session).order_by("-created_at"))

--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -178,4 +178,4 @@ class ChatMessage(UUIDPrimaryKeyBase, TimeStampedModel):
 
 
 def get_ordered_chat_messages(session: ChatHistory):
-    return list(ChatMessage.objects.filter(chat_history=session).order_by("-created_at"))
+    return list(ChatMessage.objects.filter(chat_history=session))

--- a/django_app/tests/test_models.py
+++ b/django_app/tests/test_models.py
@@ -32,7 +32,7 @@ def test_file_model_last_referenced(peter_rabbit, s3_client):  # noqa: ARG001
 
 @pytest.mark.django_db()
 def test_get_ordered_chat_messages(chat_history):
-    now = datetime.now(datetime.timezone.utc)
+    now = datetime.now(UTC)
     for seconds, text in (3, "last"), (1, "first"), (2, "middle"):
         ChatMessage.objects.create(
             chat_history=chat_history,

--- a/django_app/tests/test_models.py
+++ b/django_app/tests/test_models.py
@@ -32,14 +32,12 @@ def test_file_model_last_referenced(peter_rabbit, s3_client):  # noqa: ARG001
 
 @pytest.mark.django_db()
 def test_get_ordered_chat_messages(chat_history):
-    now = datetime.now(UTC)
-    for seconds, text in (3, "last"), (1, "first"), (2, "middle"):
-        chat_message = ChatMessage.objects.create(
+    for text in "first", "middle", "last":
+        ChatMessage.objects.create(
             chat_history=chat_history,
             text=text,
             role=ChatRoleEnum.user,
         )
-        chat_message.update(created_at=now + timedelta(seconds=seconds))
 
     chat_history = get_ordered_chat_messages(chat_history)
 

--- a/django_app/tests/test_models.py
+++ b/django_app/tests/test_models.py
@@ -34,12 +34,12 @@ def test_file_model_last_referenced(peter_rabbit, s3_client):  # noqa: ARG001
 def test_get_ordered_chat_messages(chat_history):
     now = datetime.now(UTC)
     for seconds, text in (3, "last"), (1, "first"), (2, "middle"):
-        ChatMessage.objects.create(
+        chat_message = ChatMessage.objects.create(
             chat_history=chat_history,
             text=text,
             role=ChatRoleEnum.user,
-            created_at=now + timedelta(seconds=seconds),
         )
+        chat_message.update(created_at=now + timedelta(seconds=seconds))
 
     chat_history = get_ordered_chat_messages(chat_history)
 

--- a/django_app/tests/test_models.py
+++ b/django_app/tests/test_models.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
-from redbox_app.redbox_core.models import File, StatusEnum, get_ordered_chat_messages, ChatMessage, ChatRoleEnum
+from redbox_app.redbox_core.models import ChatMessage, ChatRoleEnum, File, StatusEnum, get_ordered_chat_messages
 
 
 @pytest.mark.django_db()
@@ -32,7 +32,7 @@ def test_file_model_last_referenced(peter_rabbit, s3_client):  # noqa: ARG001
 
 @pytest.mark.django_db()
 def test_get_ordered_chat_messages(chat_history):
-    now = datetime.now()
+    now = datetime.now(datetime.timezone.utc)
     for seconds, text in (3, "last"), (1, "first"), (2, "middle"):
         ChatMessage.objects.create(
             chat_history=chat_history,


### PR DESCRIPTION
## Context

As a user I want my chant history to be passed in to the core-api in the right order

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
