### PR TITLE
Add Plausible to CSP connect-src

### DIFF
--- a/django_app/redbox_app/settings.py
+++ b/django_app/redbox_app/settings.py
@@ -164,7 +164,7 @@ CSP_FONT_SRC = (
 )
 CSP_STYLE_SRC = ("'self'",)
 CSP_FRAME_ANCESTORS = ("'none'",)
-CSP_CONNECT_SRC = ["'self'", f"wss://{ENVIRONMENT.hosts[0]}/ws/chat/"]
+CSP_CONNECT_SRC = ["'self'", f"wss://{ENVIRONMENT.hosts[0]}/ws/chat/", "plausible.io"]
 
 # https://pypi.org/project/django-permissions-policy/
 PERMISSIONS_POLICY: dict[str, list] = {


### PR DESCRIPTION
## Context

Adding `CSP_CONNECT_SRC` to the CSP broke Plausible. This is the fix for that.


## Changes proposed in this pull request

* Add Plausible to `CSP_CONNECT_SRC`


## Guidance to review

* Temporarily add the Plausible script to base.html (see lines 23-30)
* Check there are no CSP errors in the browser console
* If you temporarily remove the Plausible reference from `CSP_CONNECT_SRC` the CSP error will appear

