### PR TITLE
Show ChatMessage date in admin

### DIFF
--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -18,7 +18,7 @@ class FileResource(admin.ModelAdmin):
 class ChatMessageInline(admin.StackedInline):
     model = models.ChatMessage
     ordering = ("modified_at",)
-    readonly_fields = ["modified_at"]
+    readonly_fields = ["modified_at", "source_files"]
     extra = 1
 
 

--- a/django_app/redbox_app/redbox_core/admin.py
+++ b/django_app/redbox_app/redbox_core/admin.py
@@ -17,6 +17,8 @@ class FileResource(admin.ModelAdmin):
 
 class ChatMessageInline(admin.StackedInline):
     model = models.ChatMessage
+    ordering = ("modified_at",)
+    readonly_fields = ["modified_at"]
     extra = 1
 
 
@@ -40,8 +42,9 @@ class ChatHistoryAdmin(admin.ModelAdmin):
         return response
 
     export_as_csv.short_description = "Export Selected"
+    fields = ["name", "users"]
     inlines = [ChatMessageInline]
-    list_display = ["name", "users"]
+    list_display = ["name", "users", "modified_at"]
     list_filter = ["users"]
     actions = ["export_as_csv"]
 


### PR DESCRIPTION
## Context
We were asked to show when ChatMessages were updated in admin to make it easier to read. There were a couple of other things I noticed when auditing ChatMessages recently that were annoying and quick to fix. 

## Changes proposed in this pull request

- adds 'modified at' to the list view of all the chat histories, so we can see when they were updated
- hides 'selected_files' from the individual chat history view, as it's not used anywhere in the code
- sorts the chat messages within a chat history view by 'modifed_at', so they're seen in the right order
- shows the date each chat message was modified in the chat history view
- makes the 'source_files' for each chat message read only for readability (I looked into adding `filter_horizontal` but it needs more work to make it appear on successive ChatMessageInlines than was worth spending on this task.) 

BEFORE
<img width="921" alt="option 1" src="https://github.com/i-dot-ai/redbox-copilot/assets/23265724/36932feb-30db-48b5-9f5f-da6284a1c649">

AFTER
<img width="937" alt="option 2" src="https://github.com/i-dot-ai/redbox-copilot/assets/23265724/4243d8db-f825-49bb-a1ea-86540062dbf1">


## Guidance to review
Have a look at DjangoAdmin locally - is it readable (especially for longer chat conversations)?

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-354

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
