### PR TITLE
Feature/move secrets to secrets manager

### DIFF
--- a/infrastructure/aws/data.tf
+++ b/infrastructure/aws/data.tf
@@ -1,12 +1,22 @@
 locals {
   record_prefix = terraform.workspace == "prod" ? var.project_name : "${var.project_name}-${terraform.workspace}"
   django_host   = "${local.record_prefix}.${var.domain_name}"
-  name          = "${var.team_name}-${terraform.workspace}-${var.project_name}"
+  name          = "${var.team_name}-${terraform.workspace}-${var.project_name}"]
+
+  core_api_environment_variables = {
+    "ELASTIC_ROOT_INDEX" : "redbox-data-${terraform.workspace}",
+  }
+
+  django_app_environment_variables = {
+
+  }
+
+  worker_environment_variables = {
+
+  }
 
   environment_variables = {
-    "ELASTIC__API_KEY" : var.elastic_api_key,
-    "ELASTIC__CLOUD_ID" : var.cloud_id,
-    "ELASTIC_ROOT_INDEX" : "redbox-data-${terraform.workspace}",
+
     "OBJECT_STORE" : "s3",
     "BUCKET_NAME" : aws_s3_bucket.user_data.bucket,
     "EMBEDDING_MODEL" : "all-mpnet-base-v2",
@@ -15,11 +25,7 @@ locals {
     "REDIS_HOST" : module.elasticache.redis_address,
     "REDIS_PORT" : module.elasticache.redis_port,
     # django stuff
-    "DJANGO_SECRET_KEY" : var.django_secret_key,
-    "POSTGRES_USER" : module.rds.rds_instance_username,
-    "POSTGRES_PASSWORD" : module.rds.rds_instance_db_password,
     "POSTGRES_DB" : module.rds.db_instance_name,
-    "POSTGRES_HOST" : module.rds.db_instance_address,
     "CORE_API_HOST" : "${aws_service_discovery_service.service_discovery_service.name}.${aws_service_discovery_private_dns_namespace.private_dns_namespace.name}",
     "CORE_API_PORT" : 5002,
     "ENVIRONMENT" : upper(terraform.workspace),
@@ -29,10 +35,7 @@ locals {
     "FROM_EMAIL" : var.from_email,
     "OPENAI_API_VERSION" : var.openai_api_version,
     "AZURE_OPENAI_MODEL" : var.azure_openai_model,
-    "AZURE_OPENAI_ENDPOINT" : var.azure_openai_endpoint,
-    "AZURE_OPENAI_API_KEY" : var.azure_openai_api_key
-    "GOVUK_NOTIFY_PLAIN_EMAIL_TEMPLATE_ID" : var.govuk_notify_plain_email_template_id
-    "GOVUK_NOTIFY_API_KEY" : var.govuk_notify_api_key,
+    "GOVUK_NOTIFY_PLAIN_EMAIL_TEMPLATE_ID" : var.govuk_notify_plain_email_template_id,
     "EMAIL_BACKEND_TYPE" : "GOVUKNOTIFY",
     "USE_STREAMING" : true,
     "DJANGO_LOG_LEVEL" : "DEBUG",
@@ -40,8 +43,20 @@ locals {
     "CONTACT_EMAIL" : var.contact_email,
     "FILE_EXPIRY_IN_DAYS" : 30,
     "MAX_SECURITY_CLASSIFICATION" : "OFFICIAL_SENSITIVE",
-    "SENTRY_DSN" : var.sentry_dsn,
     "SENTRY_ENVIRONMENT" : var.sentry_environment
+  }
+
+  secrets = {
+    "ELASTIC__API_KEY" : var.elastic_api_key,
+    "ELASTIC__CLOUD_ID" : var.cloud_id,
+    "DJANGO_SECRET_KEY" : var.django_secret_key,
+    "POSTGRES_PASSWORD" : module.rds.rds_instance_db_password,
+    "POSTGRES_HOST" : module.rds.db_instance_address,
+    "POSTGRES_USER" : module.rds.rds_instance_username,
+    "AZURE_OPENAI_API_KEY" : var.azure_openai_api_key,
+    "GOVUK_NOTIFY_API_KEY" : var.govuk_notify_api_key,
+    "SENTRY_DSN" : var.sentry_dsn,
+    "AZURE_OPENAI_ENDPOINT" : var.azure_openai_endpoint,
   }
 }
 

--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -40,6 +40,33 @@ resource "aws_service_discovery_service" "service_discovery_service" {
   }
 }
 
+resource "aws_secretsmanager_secret" "core-api-secret" {
+  name = "${local.name}-core-api-secret"
+}
+
+resource "aws_secretsmanager_secret" "django-app-secret" {
+  name = "${local.name}-django-app-secret"
+}
+
+resource "aws_secretsmanager_secret" "worker-secret" {
+  name = "${local.name}-worker-secret"
+}
+
+resource "aws_secretsmanager_secret_version" "core-api-json-secret" {
+  secret_id     = aws_secretsmanager_secret.core-api-secret.id
+  secret_string = jsonencode(local.secrets)
+}
+
+resource "aws_secretsmanager_secret_version" "django-app-json-secret" {
+  secret_id     = aws_secretsmanager_secret.core-api-secret.id
+  secret_string = jsonencode(local.secrets)
+}
+
+resource "aws_secretsmanager_secret_version" "worker-json-secret" {
+  secret_id     = aws_secretsmanager_secret.core-api-secret.id
+  secret_string = jsonencode(local.secrets)
+}
+
 module "django-app" {
   memory                     = 4096
   cpu                        = 2048
@@ -47,7 +74,7 @@ module "django-app" {
   create_networking          = true
   source                     = "../../../i-ai-core-infrastructure//modules/ecs"
   name                       = "${local.name}-django-app"
-  image_tag                  = var.image_tag
+  image_tag                  = "0b3ab51276e9cc6880de232bd8620397f3ef9b7c"
   ecr_repository_uri         = "${var.ecr_repository_uri}/${var.project_name}-django-app"
   ecs_cluster_id             = module.cluster.ecs_cluster_id
   ecs_cluster_name           = module.cluster.ecs_cluster_name
@@ -80,7 +107,7 @@ module "core_api" {
   create_networking             = false
   source                        = "../../../i-ai-core-infrastructure//modules/ecs"
   name                          = "${local.name}-core-api"
-  image_tag                     = var.image_tag
+  image_tag                     = "0b3ab51276e9cc6880de232bd8620397f3ef9b7c"
   ecr_repository_uri            = "${var.ecr_repository_uri}/redbox-core-api"
   ecs_cluster_id                = module.cluster.ecs_cluster_id
   ecs_cluster_name              = module.cluster.ecs_cluster_name
@@ -111,7 +138,7 @@ module "worker" {
   create_networking            = false
   source                       = "../../../i-ai-core-infrastructure//modules/ecs"
   name                         = "${local.name}-worker"
-  image_tag                    = var.image_tag
+  image_tag                    = "0b3ab51276e9cc6880de232bd8620397f3ef9b7c"
   ecr_repository_uri           = "${var.ecr_repository_uri}/redbox-worker"
   ecs_cluster_id               = module.cluster.ecs_cluster_id
   ecs_cluster_name             = module.cluster.ecs_cluster_name

--- a/infrastructure/aws/iam.tf
+++ b/infrastructure/aws/iam.tf
@@ -15,7 +15,23 @@ data "aws_iam_policy_document" "ecs_exec_role_policy" {
     ]
     resources = [
       "arn:aws:s3:::${aws_s3_bucket.user_data.bucket}",
-      "arn:aws:s3:::${aws_s3_bucket.user_data.bucket}/*"
+      "arn:aws:s3:::${aws_s3_bucket.user_data.bucket}/*",
+
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+    resources = [
+       aws_secretsmanager_secret.core-api-secret.arn,
+       "${aws_secretsmanager_secret.core-api-secret.arn}:*",
+       aws_secretsmanager_secret.worker-secret.arn,
+       "${aws_secretsmanager_secret.worker-secret.arn}:*",
+       aws_secretsmanager_secret.django-app-secret.arn,
+       "${aws_secretsmanager_secret.django-app-secret.arn}:*",
     ]
   }
 


### PR DESCRIPTION
## Context

Currently the ECS just contains all the secrets in the env, so if you can get to the task you can see all the secrets

## Changes proposed in this pull request

- Separate env and secrets into separate variables for each ecs task
- Push them to secrets manager
- Give secrets as a var to each ecs module
- Update the IAM role that executes the ecs tasks to be able to read secrets

## Guidance to review

- Go to the ecs task for dev in aws console and see that the secrets there are the secret manager arns instead

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
