### PR TITLE
Only show docs on chat page where processing is complete

### DIFF
--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -205,8 +205,7 @@ class ChatsView(View):
             messages = ChatMessage.objects.filter(chat_history__id=chat_id).order_by("created_at")
         endpoint = URL.build(scheme=settings.WEBSOCKET_SCHEME, host=request.get_host(), path=r"/ws/chat/")
 
-        hidden_statuses = [StatusEnum.deleted, StatusEnum.errored]
-        all_files = File.objects.filter(user=request.user).exclude(status__in=hidden_statuses).order_by("-created_at")
+        all_files = File.objects.filter(user=request.user, status=StatusEnum.complete).order_by("-created_at")
         self.decorate_selected_files(all_files, messages)
 
         context = {


### PR DESCRIPTION
## Context

All docs are available for selection on the chat page. We want to only allow users to select docs where the processing has completed.

https://technologyprogramme.atlassian.net/browse/REDBOX-356?atlOrigin=eyJpIjoiMDQ4YmUwYjA1MjVmNDU5ZWJmODFhZjNhYTZlYTUyM2MiLCJwIjoiaiJ9


## Changes proposed in this pull request

* Filter by status = complete


## Guidance to review

* Upload a doc (a larger doc may be easier to enable time to check)
* Check it only appears on chat page once process is complete
