### PR TITLE
Communicate route choice to FE

### DIFF
--- a/core_api/src/routes/chat.py
+++ b/core_api/src/routes/chat.py
@@ -160,7 +160,7 @@ async def rag_chat(
 
     if route_response := ROUTE_RESPONSES.get(route.name):
         response = route_response.invoke({})
-        return ChatResponse(output_text=response.messages[0].content)
+        return ChatResponse(output_text=response.messages[0].content, route=route.name)
 
     # build_vanilla_chain could go here
 
@@ -177,7 +177,7 @@ async def rag_chat(
         )
         for langchain_document in result.get("input_documents", [])
     ]
-    return ChatResponse(output_text=result["output_text"], source_documents=source_documents)
+    return ChatResponse(output_text=result["output_text"], source_documents=source_documents, route='rag')
 
 
 @chat_app.websocket("/rag")

--- a/core_api/src/routes/chat.py
+++ b/core_api/src/routes/chat.py
@@ -24,7 +24,7 @@ from redbox.llm.prompts.chat import (
     STUFF_DOCUMENT_PROMPT,
     WITH_SOURCES_PROMPT,
 )
-from redbox.models.chat import ChatRequest, ChatResponse, SourceDocument
+from redbox.models.chat import ChatRequest, ChatResponse, ChatRouteEnum, SourceDocument
 
 # === Logging ===
 
@@ -50,12 +50,16 @@ chat_app = FastAPI(
 )
 
 ROUTE_RESPONSES = {
-    "info": ChatPromptTemplate.from_template(INFO_RESPONSE),
-    "ability": ChatPromptTemplate.from_template(ABILITY_RESPONSE),
-    "coach": ChatPromptTemplate.from_template(COACH_RESPONSE),
-    "gratitude": ChatPromptTemplate.from_template("You're welcome!"),
-    "summarisation": ChatPromptTemplate.from_template("You are asking for summarisation - route not yet implemented"),
-    "extract": ChatPromptTemplate.from_template("You asking to extract some information - route not yet implemented"),
+    ChatRouteEnum.info: ChatPromptTemplate.from_template(INFO_RESPONSE),
+    ChatRouteEnum.ability: ChatPromptTemplate.from_template(ABILITY_RESPONSE),
+    ChatRouteEnum.coach: ChatPromptTemplate.from_template(COACH_RESPONSE),
+    ChatRouteEnum.gratitude: ChatPromptTemplate.from_template("You're welcome!"),
+    ChatRouteEnum.summarisation: ChatPromptTemplate.from_template(
+        "You are asking for summarisation - route not yet implemented"
+    ),
+    ChatRouteEnum.extract: ChatPromptTemplate.from_template(
+        "You asking to extract some information - route not yet implemented"
+    ),
 }
 
 
@@ -177,7 +181,7 @@ async def rag_chat(
         )
         for langchain_document in result.get("input_documents", [])
     ]
-    return ChatResponse(output_text=result["output_text"], source_documents=source_documents, route='rag')
+    return ChatResponse(output_text=result["output_text"], source_documents=source_documents, route=ChatRouteEnum.rag)
 
 
 @chat_app.websocket("/rag")

--- a/core_api/tests/routes/test_chat.py
+++ b/core_api/tests/routes/test_chat.py
@@ -63,6 +63,7 @@ def test_rag_chat(app_client, headers):
     )
     response_dict = response.json()
     assert response_dict["output_text"] == "You're welcome!"
+    assert response_dict["route"] == "gratitude"
 
 
 def test_rag_chat_streamed(app_client, headers):

--- a/core_api/tests/routes/test_chat.py
+++ b/core_api/tests/routes/test_chat.py
@@ -104,12 +104,14 @@ def test_rag_chat_streamed(app_client, headers):
         # When
         websocket.send_text(json.dumps({"message_history": message_history, "selected_files": selected_files}))
 
-        all_text, docs = [], []
+        all_text, docs, route = [], [], ""
         while True:
             try:
                 actual = websocket.receive_json()
                 if actual["resource_type"] == "text":
                     all_text.append(actual["data"])
+                    if route == "":
+                        route = actual["route"]
                 if actual["resource_type"] == "documents":
                     docs.append(actual["data"])
             except WebSocketDisconnect:
@@ -118,6 +120,7 @@ def test_rag_chat_streamed(app_client, headers):
         # Then
         text = "".join(all_text)
         assert "Barry Mann" in text
+        assert route == "rag"
 
 
 def mock_build_retrieval_chain(events):

--- a/redbox/models/chat.py
+++ b/redbox/models/chat.py
@@ -1,7 +1,19 @@
+from enum import Enum
 from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field
+
+
+class ChatRouteEnum(str, Enum):
+    info = "info"
+    ability = "ability"
+    coach = "coach"
+    gratitude = "gratitude"
+    summarisation = "summarisation"
+    extract = "extract"
+    rag = "rag"
+    vanilla = "vanilla"
 
 
 class ChatMessage(BaseModel):
@@ -68,4 +80,7 @@ class ChatResponse(BaseModel):
     output_text: str = Field(
         description="response text",
         examples=["The current Prime Minister of the UK is The Rt Hon. Rishi Sunak MP."],
+    )
+    route: ChatRouteEnum = Field(
+        description="the conversation route taken"
     )

--- a/redbox/models/chat.py
+++ b/redbox/models/chat.py
@@ -81,6 +81,4 @@ class ChatResponse(BaseModel):
         description="response text",
         examples=["The current Prime Minister of the UK is The Rt Hon. Rishi Sunak MP."],
     )
-    route: ChatRouteEnum = Field(
-        description="the conversation route taken"
-    )
+    route: ChatRouteEnum = Field(description="the conversation route taken")


### PR DESCRIPTION
## Context

Returns the route selected in core_api to the Django FE. Django doesn't do anything with this yet, as there are some design decisions to make.

## Changes proposed in this pull request

- Adds a ChatRouteEnum in `redbox/models` to consolidate route names
- returns 'route' in `ChatResponse` and in the streaming response
- tests the above

## Guidance to review
Have I tested enough? Do I need to return this for all the streaming events?

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-326

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
