### PR TITLE
Feature/stop streaming

### DIFF
--- a/django_app/frontend/js/chats/streaming.js
+++ b/django_app/frontend/js/chats/streaming.js
@@ -44,7 +44,13 @@ customElements.define('sources-list', SourcesList);
 
 class ChatMessage extends HTMLElement {
 
-    connectedCallback() {
+    constructor() {
+        super();
+        /** Whether the stream has completed - separate to data-status, as it could be paused and completed at the same time */
+        this.complete = false;
+    }
+
+    connectedCallback() {        
         this.innerHTML = `
             <div class="iai-chat-message iai-chat-message--${this.dataset.role} govuk-body">
                 <div class="iai-chat-message__role">${this.dataset.role === 'ai' ? 'Redbox' : 'You'}</div>
@@ -52,12 +58,14 @@ class ChatMessage extends HTMLElement {
                     `<div class="iai-streaming-response-loading js-streaming-response-loading govuk-!-margin-top-1" tabindex="-1">
                         <img class="iai-streaming-response-loading__spinner" src="/static/images/spinner.gif" alt=""/>
                         <p class="iai-streaming-response-loading__text govuk-body-s govuk-!-margin-bottom-0 govuk-!-margin-left-1">Response loading...</p>
-                    </div>`
+                    </div>
+                    <button class="iai-streaming-response-paused js-streaming-response-paused">Continue</button>`
                 : ''}
                 <markdown-converter class="iai-chat-message__text">${this.dataset.text || ''}</markdown-converter>
                 <sources-list></sources-list>
             </div>
         `;
+        /** @type HTMLButtonElement */(this.querySelector('.js-streaming-response-paused')).style.visibility = 'hidden';
     }
 
     /**
@@ -73,26 +81,53 @@ class ChatMessage extends HTMLElement {
         let responseContainer = /** @type MarkdownConverter */(this.querySelector('markdown-converter'));
         let sourcesContainer = /** @type SourcesList */(this.querySelector('sources-list'));
         let responseLoading = /** @type HTMLElement */(this.querySelector('.js-streaming-response-loading'));
+        let pauseButton = /** @type HTMLButtonElement */(this.querySelector('.js-streaming-response-paused'));
         let webSocket = new WebSocket(endPoint);
         let streamedContent = '';
         let sources = [];
+
+        const displayLatestContent = () => {
+            responseContainer.update(streamedContent);
+            sources.forEach((source) => {
+                sourcesContainer.add(source.name, source.url);
+            });
+            sources = [];
+        };
+
+        // pause streaming if user presses escape key and response is in view
+        document.body.addEventListener('keydown', (evt) => {
+            if (evt.key !== 'Escape' && !this.complete) {
+              return;
+            }
+            const rect = this.getBoundingClientRect();
+            if (rect.bottom > 0 && rect.top < window.innerHeight) {
+              this.dataset.status = 'paused';
+            }
+        });
+        pauseButton.addEventListener('click', () => {
+            this.dataset.status = this.complete ? 'complete' : 'streaming';
+            pauseButton.style.visibility = 'hidden';
+            displayLatestContent();
+        });
     
         webSocket.onopen = (event) => {
             webSocket.send(JSON.stringify({message: message, sessionId: sessionId, selectedFiles: selectedDocuments}));
-            this.dataset.status = "streaming";
+            this.dataset.status = 'streaming';
         };
     
         webSocket.onerror = (event) => {
             responseContainer.innerHTML = 'There was a problem. Please try sending this message again.';
-            this.dataset.status = "error";
+            this.dataset.status = 'error';
         };
 
         webSocket.onclose = (event) => {
-            this.dataset.status = "complete";
+            this.complete = true;
+            if (this.dataset.status !== 'paused') {
+                this.dataset.status = 'complete';
+            }
         };
     
         webSocket.onmessage = (event) => {
-            
             let message;
             try {
                 message = JSON.parse(event.data);
@@ -103,11 +138,18 @@ class ChatMessage extends HTMLElement {
             if (message.type === 'text') {
                 responseLoading.style.display = 'none';
                 streamedContent += message.data;
-                responseContainer.update(streamedContent);
             } else if (message.type === 'session-id') {
                 chatControllerRef.dataset.sessionId = message.data;
             } else if (message.type === 'source') {
-                sourcesContainer.add(message.data.original_file_name, message.data.url);
+                sources.push({
+                    name: message.data.original_file_name,
+                    url: message.data.url
+                });
+            }
+
+            // Make update visible to user
+            if (this.dataset.status !== 'paused') {
+                displayLatestContent();
             }
             
         };


### PR DESCRIPTION
## Context

We need to be able to stop streaming responses for two reasons:
* An accessibility requirement to be able to pause any auto-updating content lasting longer than 5 seconds
* Users may wish to stop the response (e.g. pressed enter too soon, or wanting to ask something slightly different)

The escape key is a standard way to do this, and is recognised as a suitable approach for accessibility.


## Changes proposed in this pull request

* Allow streaming to be stopped by pressing the escape key


## Guidance to review

Start a chat, press the escape key


## Relevant links

https://technologyprogramme.atlassian.net/browse/REDBOX-368?atlOrigin=eyJpIjoiODM5ZTIyZDFhZDg0NGU1ZjgyNTZlNWE3NjNmOTQ4N2MiLCJwIjoiaiJ9


## Things to think about
* Should we have some text to say "[stream stopped]" or something similar? Or is it clear enough as is?
* We could have a button to stop the stream, but thought it best to wait for the design updates to see if we should add it in then. This PR can be seen as a first step.
* The first commit in this PR added a button (after stopping it) allowing users to resume the stream. I removed this as I felt it was overcomplicating things and we haven't yet identified a user need for this. The code is there, should we wish to revisit this at some point.
