### PR TITLE
Update REST `rag_chat` endpoint to include the stuff summarisation already in streaming endpoint

### DIFF
--- a/core_api/tests/routes/test_chat.py
+++ b/core_api/tests/routes/test_chat.py
@@ -55,7 +55,7 @@ def mock_get_chain():
 #     assert response.status_code == status_code
 
 
-def test_rag_chat(app_client, headers):
+def test_rag_chat_rest_gratitude(app_client, headers):
     response = app_client.post(
         "/chat/rag",
         json={"message_history": [{"role": "user", "text": "Thank you"}]},
@@ -63,6 +63,23 @@ def test_rag_chat(app_client, headers):
     )
     response_dict = response.json()
     assert response_dict["output_text"] == "You're welcome!"
+
+
+def test_rag_chat_rest_stuff_summarise(app_client, headers):
+    response = app_client.post(
+        "/chat/rag",
+        json={
+            "message_history": [
+                {
+                    "role": "user",
+                    "text": "Please summarise the contents of the uploaded files.",
+                }
+            ]
+        },
+        headers=headers,
+    )
+    response_dict = response.json()
+    assert isinstance(response_dict["output_text"], str)
 
 
 def test_rag_chat_streamed(app_client, headers):


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We want both the streaming endpoint point and REST endpoint to have the same functionality.

`stuff_summarisation` has recently been added to `main` using Langchain Expression Language (LCEL) runnables. This work adds the same `stuff_summarisation` functionality, using the same LCEL runnables to the REST `rag_chat` endpoint.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Updated REST `rag_chat` endpoint and added basic test to check the type of response when sent down the `stuff_summarisation` route. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests
