### PR TITLE
Send route name to the front end

### DIFF
--- a/redbox/models/chat.py
+++ b/redbox/models/chat.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Literal
 from uuid import UUID
 
@@ -61,6 +62,17 @@ class SourceDocuments(BaseModel):
     )
 
 
+class ChatRoute(str, Enum):
+    info = "info"
+    ability = "ability"
+    coach = "coach"
+    gratitude = "gratitude"
+    retrieval = "retrieval"
+    summarisation = "summarisation"
+    extract = "extract"
+    vanilla = "vanilla"
+
+
 class ChatResponse(BaseModel):
     source_documents: list[SourceDocument] | None = Field(
         description="documents retrieved to form this response", default=None
@@ -69,3 +81,4 @@ class ChatResponse(BaseModel):
         description="response text",
         examples=["The current Prime Minister of the UK is The Rt Hon. Rishi Sunak MP."],
     )
+    route: ChatRoute = Field(description="the conversation route taken")


### PR DESCRIPTION
## Context
Adds the changes proposed in #574 (which was closed until other things were merged in the mean time).

## Changes proposed in this pull request

- Adds a `ChatRoute` class in redbox/models to consolidate route names
- returns 'route' in ChatResponse and in the streaming response
- tests the above

## Guidance to review

Have I tested enough? Am I using the appropriate streaming event

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-326

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
