### PR TITLE
bugfix/AZURE_API_VERSION

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,7 +1,5 @@
 # === LLM  ===
 
-ANTHROPIC_API_KEY=
-OPENAI_API_KEY=
 LLM_MAX_TOKENS=1024
 
 # === Development ===

--- a/core_api/src/dependencies.py
+++ b/core_api/src/dependencies.py
@@ -77,7 +77,7 @@ async def get_llm(env: Annotated[Settings, Depends(get_env)]) -> ChatLiteLLM:
         # this nasty hack is required because, contrary to the docs:
         # using the api_version argument is not sufficient, and we need
         # to use the `OPENAI_API_VERSION` environment variable
-        os.environ["OPENAI_API_VERSION"] = env.openai_api_version
+        os.environ["AZURE_API_VERSION"] = env.openai_api_version
         os.environ["AZURE_OPENAI_API_KEY"] = env.azure_openai_api_key
 
         llm = ChatLiteLLM(

--- a/core_api/src/dependencies.py
+++ b/core_api/src/dependencies.py
@@ -77,8 +77,15 @@ async def get_llm(env: Annotated[Settings, Depends(get_env)]) -> ChatLiteLLM:
         # this nasty hack is required because, contrary to the docs:
         # using the api_version argument is not sufficient, and we need
         # to use the `OPENAI_API_VERSION` environment variable
-        os.environ["AZURE_API_VERSION"] = env.openai_api_version
-        os.environ["AZURE_OPENAI_API_KEY"] = env.azure_openai_api_key
+        if env.azure_openai_api_key:
+            os.environ["AZURE_API_VERSION"] = env.openai_api_version
+            os.environ["AZURE_OPENAI_API_KEY"] = env.azure_openai_api_key
+        elif env.openai_api_key:
+            os.environ["OPENAI_API_VERSION"] = env.openai_api_version
+            os.environ["OPENAI_API_KEY"] = env.openai_api_key
+        else:
+            msg = "either AZURE_API_VERSION or OPENAI_API_VERSION must be set"
+            raise ValueError(msg)
 
         llm = ChatLiteLLM(
             model=env.azure_openai_model,

--- a/redbox/models/settings.py
+++ b/redbox/models/settings.py
@@ -39,6 +39,7 @@ class Settings(BaseSettings):
     azure_openai_endpoint: str | None = None
 
     openai_api_version: str = "2023-12-01-preview"
+    azure_api_version: str = "2023-12-01-preview"
     azure_openai_model: str = "azure/gpt-35-turbo-16k"
     llm_max_tokens: int = 1024
 


### PR DESCRIPTION
## Context

When using an Azure instance of OpenAI we need to specify: `AZURE_API_VERSION` rather than `OPENAI_API_VERSION`

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [x] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/9518119430
