### PR TITLE
Patches for streaming

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,8 @@
     },
     "python.analysis.autoImportCompletions": true,
     "python.testing.pytestArgs": [
-        "core_api"
+        "core_api",
+        "tests"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,8 +8,7 @@
     },
     "python.analysis.autoImportCompletions": true,
     "python.testing.pytestArgs": [
-        "core_api",
-        "tests"
+        "core_api"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true

--- a/core_api/src/runnables.py
+++ b/core_api/src/runnables.py
@@ -44,7 +44,9 @@ def map_to_chat_response(input_dict: dict):
                 file_uuid=chunk.parent_file_uuid,
                 page_numbers=chunk.metadata.page_number
                 if isinstance(chunk.metadata.page_number, list)
-                else [chunk.metadata.page_number],
+                else [chunk.metadata.page_number]
+                if chunk.metadata.page_number
+                else [],
             )
             for chunk in input_dict.get("source_documents", [])
         ],

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -12,7 +12,7 @@ from jose import jwt
 from websockets import ConnectionClosed
 
 USER_UUIDS: list[UUID] = [uuid4(), uuid4()]
-TEST_ORIGIN = "localhost:8080"
+TEST_ORIGIN = "localhost:5002"
 
 
 def make_headers(user_uuid: UUID):

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -12,7 +12,8 @@ from jose import jwt
 from websockets import ConnectionClosed
 
 USER_UUIDS: list[UUID] = [uuid4(), uuid4()]
-TEST_ORIGIN="localhost:8080"
+TEST_ORIGIN = "localhost:8080"
+
 
 def make_headers(user_uuid: UUID):
     token = jwt.encode({"user_uuid": str(user_uuid)}, key="super-secure-private-key")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -12,7 +12,7 @@ from jose import jwt
 from websockets import ConnectionClosed
 
 USER_UUIDS: list[UUID] = [uuid4(), uuid4()]
-
+TEST_ORIGIN="localhost:8080"
 
 def make_headers(user_uuid: UUID):
     token = jwt.encode({"user_uuid": str(user_uuid)}, key="super-secure-private-key")
@@ -43,7 +43,7 @@ class TestEndToEnd:
             )
 
             response = requests.post(
-                url="http://localhost:5002/file",
+                url=f"http://{TEST_ORIGIN}/file",
                 json={
                     "key": file_key,
                     "bucket": bucket_name,
@@ -69,7 +69,7 @@ class TestEndToEnd:
         while time.time() - start_time < timeout:
             time.sleep(1)
             chunk_response = requests.get(
-                f"http://localhost:5002/file/{TestEndToEnd.file_uuids[user_uuid]}/status",
+                f"http://{TEST_ORIGIN}/file/{TestEndToEnd.file_uuids[user_uuid]}/status",
                 headers=make_headers(user_uuid),
                 timeout=30,
             )
@@ -91,7 +91,7 @@ class TestEndToEnd:
         I Expect a 200 response code
         """
         chunks_response = requests.get(
-            f"http://localhost:5002/file/{TestEndToEnd.file_uuids[user_uuid]}/chunks",
+            f"http://{TEST_ORIGIN}/file/{TestEndToEnd.file_uuids[user_uuid]}/chunks",
             headers=make_headers(user_uuid),
             timeout=30,
         )
@@ -106,7 +106,7 @@ class TestEndToEnd:
         I Expect an answer and for the cited documents to be the one I uploaded
         """
         rag_response = requests.post(
-            "http://localhost:5002/chat/rag",
+            f"http://{TEST_ORIGIN}/chat/rag",
             json={
                 "message_history": [
                     {"role": "user", "text": "what is routing?"},
@@ -132,7 +132,7 @@ class TestEndToEnd:
         I Expect an answer and for no cited documents to be returned
         """
         rag_response = requests.post(
-            "http://localhost:5002/chat/rag",
+            f"http://{TEST_ORIGIN}/chat/rag",
             json={
                 "message_history": [
                     {"role": "user", "text": "what is routing?"},
@@ -179,7 +179,7 @@ class TestEndToEnd:
         all_text, source_documents = [], []
 
         async for websocket in websockets.connect(
-            "ws://localhost:5002/chat/rag", extra_headers=make_headers(user_uuid)
+            f"ws://{TEST_ORIGIN}/chat/rag", extra_headers=make_headers(user_uuid)
         ):
             await websocket.send(json.dumps(message_history))
 
@@ -216,7 +216,7 @@ class TestEndToEnd:
         all_text, source_documents = [], []
 
         async for websocket in websockets.connect(
-            "ws://localhost:5002/chat/rag", extra_headers=make_headers(user_uuid)
+            f"ws://{TEST_ORIGIN}/chat/rag", extra_headers=make_headers(user_uuid)
         ):
             await websocket.send(json.dumps(message_history))
 
@@ -236,7 +236,7 @@ class TestEndToEnd:
     @pytest.mark.parametrize("user_uuid", USER_UUIDS)
     def test_post_rag_stuff(self, user_uuid):
         rag_response = requests.post(
-            "http://localhost:5002/chat/rag",
+            f"http://{TEST_ORIGIN}/chat/rag",
             json={
                 "message_history": [
                     {


### PR DESCRIPTION
## Context

Integration tests are failing on main

## Changes proposed in this pull request

The handling of page numbers in ChatResponse now accounts for all possibilities. This fix is ugly, there's a better fix in there somewhere but it needs thinking about.
With the move to LCEL runnables for chains we've lost access to some of the streaming events. This breaks the fixed prompt based responses so this has been patched. This fix matches the existing behaviour ( I think! ) of returning text emitted by the prompt and the LLM but this means the retrieval pipeline will return both the prompt and the LLM response which feels wrong? The test passes but I'm not sure about this behaviour

## Guidance to review

The websocket streaming chat path function seems to be doing what was done before but if somebody can shed any light on how the frontend is going to handle receiving event messages for the prompt and LLM that'd be good.

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
