### PR TITLE
Make demographic data optional again.

### DIFF
--- a/django_app/redbox_app/redbox_core/models.py
+++ b/django_app/redbox_app/redbox_core/models.py
@@ -89,9 +89,9 @@ class User(BaseUser, UUIDPrimaryKeyBase):
     invite_accepted_at = models.DateTimeField(default=None, blank=True, null=True)
     last_token_sent_at = models.DateTimeField(editable=False, blank=True, null=True)
     password = models.CharField("password", max_length=128, blank=True, null=True)
-    grade = models.CharField(null=True, max_length=3, choices=UserGrade)
-    profession = models.CharField(null=True, max_length=4, choices=Profession)
-    business_unit = models.ForeignKey(BusinessUnit, null=True, on_delete=models.SET_NULL)
+    grade = models.CharField(null=True, blank=True, max_length=3, choices=UserGrade)
+    profession = models.CharField(null=True, blank=True, max_length=4, choices=Profession)
+    business_unit = models.ForeignKey(BusinessUnit, null=True, blank=True, on_delete=models.SET_NULL)
     objects = BaseUserManager()
 
     def __str__(self) -> str:  # pragma: no cover


### PR DESCRIPTION
## Context

Demographic data should be optional.

I do *not* know how this went missing.

## Changes proposed in this pull request

Make demographic data optional.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
