### PR TITLE
bugfix/add-routes-to-output

### DIFF
--- a/redbox/models/chat.py
+++ b/redbox/models/chat.py
@@ -54,6 +54,9 @@ class SourceDocument(BaseModel):
         description="page number of the file that this chunk came from", default=None
     )
 
+    def __hash__(self):
+        return hash(self.page_content) ^ hash(self.file_uuid) ^ hash(tuple(self.page_numbers))
+
 
 class SourceDocuments(BaseModel):
     source_documents: list[SourceDocument] | None = Field(


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

1. added route to the response payload
2. use the route to ensure that we do not send back the rag/summary prompt (this is very hacky but will do for now)
3. added hash to DocumentSource so it can be de-duplicated

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/9566739959
