### PR TITLE
Bugfix/duplicated prompt in response

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "args": [
                 "core_api.src.app:app",
                 "--reload",
-                "--port", "8080"
+                "--port", "5002"
             ],
             "jinja": true,
             "envFile": "${workspaceFolder}/.env"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,9 +7,6 @@
         "editor.defaultFormatter": "ms-python.black-formatter"
     },
     "python.analysis.autoImportCompletions": true,
-    "python.testing.pytestArgs": [
-        "core_api"
-    ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true
 }

--- a/core_api/src/dependencies.py
+++ b/core_api/src/dependencies.py
@@ -1,7 +1,7 @@
 import logging
 import os
-from typing import Annotated, Any, TypedDict
 from functools import lru_cache
+from typing import Annotated, Any, TypedDict
 
 from elasticsearch import Elasticsearch
 from fastapi import Depends
@@ -74,8 +74,7 @@ class ESQuery(TypedDict):
 
 @lru_cache(1)
 def get_es_retriever(
-    env: Annotated[Settings, Depends(get_env)],
-    es: Annotated[Elasticsearch, Depends(get_elasticsearch_client)]
+    env: Annotated[Settings, Depends(get_env)], es: Annotated[Elasticsearch, Depends(get_elasticsearch_client)]
 ) -> ElasticsearchRetriever:
     """Creates an Elasticsearch retriever runnable.
 

--- a/core_api/src/routes/chat.py
+++ b/core_api/src/routes/chat.py
@@ -81,35 +81,26 @@ async def rag_chat_streamed(
 
     selected_chain, params = await semantic_router_to_chain(chat_request, user_uuid, routable_chains, route_layer)
 
-    async for event in selected_chain.astream_events(params.model_dump(), version="v1"):
-        kind = event["event"]
-        if kind == "on_chat_model_stream":
-            await websocket.send_json({"resource_type": "text", "data": event["data"]["chunk"].content})
-        elif kind == "on_chat_model_end":
-            await websocket.send_json({"resource_type": "end"})
-        elif kind == "on_chain_stream":
-            if isinstance(event["data"]["chunk"], dict):
-                source_chunks = event["data"]["chunk"].get("source_documents", [])
-                source_documents = [
-                    jsonable_encoder(
-                        SourceDocument(
-                            page_content=chunk.text,
-                            file_uuid=chunk.parent_file_uuid,
-                            page_numbers=chunk.metadata.page_number
-                            if isinstance(chunk.metadata.page_number, list)
-                            else [chunk.metadata.page_number]
-                            if chunk.metadata.page_number
-                            else [],
-                        )
-                    )
-                    for chunk in source_chunks
-                ]
-                await websocket.send_json({"resource_type": "documents", "data": source_documents})
-        elif kind == "on_prompt_end":
-            try:
-                msg = event["data"]["output"].messages[0].content
-                await websocket.send_json({"resource_type": "text", "data": msg})
-            except (KeyError, AttributeError):
-                logging.exception("unknown message format %s", str(event["data"]["output"]))
-
+    async for event in selected_chain.astream(params.model_dump()):
+        response = event.get("response", "")
+        source_chunks = event.get("source_documents", [])
+        source_documents = [
+            jsonable_encoder(
+                SourceDocument(
+                    page_content=chunk.text,
+                    file_uuid=chunk.parent_file_uuid,
+                    page_numbers=chunk.metadata.page_number
+                    if isinstance(chunk.metadata.page_number, list)
+                    else [chunk.metadata.page_number]
+                    if chunk.metadata.page_number
+                    else [],
+                )
+            )
+            for chunk in source_chunks
+        ]
+        if response:
+            await websocket.send_json({"resource_type": "text", "data": response})
+        if source_documents:
+            await websocket.send_json({"resource_type": "documents", "data": source_documents})
+    await websocket.send_json({"resource_type": "end"})
     await websocket.close()

--- a/core_api/src/semantic_routes.py
+++ b/core_api/src/semantic_routes.py
@@ -1,10 +1,9 @@
-from functools import lru_cache
 from typing import Annotated
 
 from fastapi import Depends
 from langchain_core.runnables import Runnable
 from semantic_router import Route
-from semantic_router.encoders import BaseEncoder, HuggingFaceEncoder
+from semantic_router.encoders import HuggingFaceEncoder
 from semantic_router.layer import RouteLayer
 
 from core_api.src.build_chains import build_retrieval_chain, build_static_response_chain, build_summary_chain
@@ -106,25 +105,26 @@ extract = Route(
     ],
 )
 
-__semantic_routing_encoder=None
-__routable_chains=None
-__semantic_route_layer=None
+__semantic_routing_encoder = None
+__routable_chains = None
+__semantic_route_layer = None
+
 
 def get_semantic_routes():
     return (info, ability, coach, gratitude, summarisation)
 
 
 def get_semantic_routing_encoder():
-    global __semantic_routing_encoder
+    global __semantic_routing_encoder  # noqa: PLW0603
     if not __semantic_routing_encoder:
-        __semantic_routing_encoder = HuggingFaceEncoder(name="sentence-transformers/paraphrase-albert-small-v2", cache_dir=MODEL_PATH)
+        __semantic_routing_encoder = HuggingFaceEncoder(
+            name="sentence-transformers/paraphrase-albert-small-v2", cache_dir=MODEL_PATH
+        )
     return __semantic_routing_encoder
 
 
-def get_semantic_route_layer(
-    routes: Annotated[list[Route], Depends(get_semantic_routes)]
-):
-    global __semantic_route_layer
+def get_semantic_route_layer(routes: Annotated[list[Route], Depends(get_semantic_routes)]):
+    global __semantic_route_layer  # noqa: PLW0603
     if not __semantic_route_layer:
         __semantic_route_layer = RouteLayer(encoder=get_semantic_routing_encoder(), routes=routes)
     return __semantic_route_layer
@@ -134,7 +134,7 @@ def get_routable_chains(
     retrieval_chain: Annotated[Runnable, Depends(build_retrieval_chain)],
     summary_chain: Annotated[Runnable, Depends(build_summary_chain)],
 ):
-    global __routable_chains
+    global __routable_chains  # noqa: PLW0603
     if not __routable_chains:
         __routable_chains = {
             "info": build_static_response_chain(INFO_RESPONSE),

--- a/core_api/tests/routes/test_chat.py
+++ b/core_api/tests/routes/test_chat.py
@@ -127,7 +127,7 @@ def test_summary(mock_client, headers):
     assert chat_response.output_text == RAG_LLM_RESPONSE
 
 
-def test_rag_chat_streamed(mock_streaming_client, headers):
+def test_rag_chat_streamed(mock_client, headers):
     # Given
     message_history = [
         {"text": "What can I do for you?", "role": "system"},
@@ -138,7 +138,7 @@ def test_rag_chat_streamed(mock_streaming_client, headers):
         {"uuid": "219c2e94-9877-4f83-ad6a-a59426f90171"},
     ]
 
-    with mock_streaming_client.websocket_connect("/chat/rag", headers=headers) as websocket:
+    with mock_client.websocket_connect("/chat/rag", headers=headers) as websocket:
         # When
         websocket.send_text(json.dumps({"message_history": message_history, "selected_files": selected_files}))
 
@@ -154,5 +154,5 @@ def test_rag_chat_streamed(mock_streaming_client, headers):
                 break
 
         # Then
-        text = " ".join(all_text)
+        text = "".join(all_text)
         assert text == RAG_LLM_RESPONSE

--- a/core_api/tests/test_runnables.py
+++ b/core_api/tests/test_runnables.py
@@ -60,7 +60,7 @@ def test_get_file_chunked_to_tokens(chunked_file, elasticsearch_storage_handler)
     assert len(many_documents) > 1
 
 
-def test_make_es_retriever(es_client, embedding_model, chunked_file):
+def test_make_es_retriever(es_client, chunked_file):
     retriever = get_es_retriever(es=es_client, env=env)
 
     one_doc_chunks = retriever.invoke(
@@ -103,7 +103,7 @@ def test_make_condense_question_runnable(mock_llm):
     assert response == "<<TESTING>>"
 
 
-def test_make_condense_rag_runnable(es_client, embedding_model, mock_llm, chunked_file):
+def test_make_condense_rag_runnable(es_client, mock_llm, chunked_file):
     retriever = get_es_retriever(es=es_client, env=env)
 
     chain = make_condense_rag_runnable(system_prompt="Your job is Q&A.", llm=mock_llm, retriever=retriever)
@@ -127,7 +127,7 @@ def test_make_condense_rag_runnable(es_client, embedding_model, mock_llm, chunke
     assert {chunked_file.uuid} == {chunk.parent_file_uuid for chunk in response["sources"]}
 
 
-def test_rag_runnable(es_client, embedding_model, mock_llm, chunked_file, env):
+def test_rag_runnable(es_client, mock_llm, chunked_file, env):
     retriever = get_es_retriever(es=es_client, env=env)
 
     chain = build_retrieval_chain(llm=mock_llm, retriever=retriever, env=env)

--- a/core_api/tests/test_runnables.py
+++ b/core_api/tests/test_runnables.py
@@ -61,7 +61,7 @@ def test_get_file_chunked_to_tokens(chunked_file, elasticsearch_storage_handler)
 
 
 def test_make_es_retriever(es_client, embedding_model, chunked_file):
-    retriever = get_es_retriever(es=es_client, embedding_model=embedding_model, env=env)
+    retriever = get_es_retriever(es=es_client, env=env)
 
     one_doc_chunks = retriever.invoke(
         input={
@@ -104,7 +104,7 @@ def test_make_condense_question_runnable(mock_llm):
 
 
 def test_make_condense_rag_runnable(es_client, embedding_model, mock_llm, chunked_file):
-    retriever = get_es_retriever(es=es_client, embedding_model=embedding_model, env=env)
+    retriever = get_es_retriever(es=es_client, env=env)
 
     chain = make_condense_rag_runnable(system_prompt="Your job is Q&A.", llm=mock_llm, retriever=retriever)
 
@@ -128,7 +128,7 @@ def test_make_condense_rag_runnable(es_client, embedding_model, mock_llm, chunke
 
 
 def test_rag_runnable(es_client, embedding_model, mock_llm, chunked_file, env):
-    retriever = get_es_retriever(es=es_client, embedding_model=embedding_model, env=env)
+    retriever = get_es_retriever(es=es_client, env=env)
 
     chain = build_retrieval_chain(llm=mock_llm, retriever=retriever, env=env)
 

--- a/redbox/models/settings.py
+++ b/redbox/models/settings.py
@@ -39,6 +39,7 @@ SUMMARISATION_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {doc
 
 class AISettings(BaseModel):
     """prompts and other AI settings"""
+    model_config = SettingsConfigDict(frozen=True)
 
     rag_k: int = 5
     rag_num_candidates: int = 10
@@ -51,6 +52,7 @@ class AISettings(BaseModel):
 
 class ElasticLocalSettings(BaseModel):
     """settings required for a local/ec2 instance of elastic"""
+    model_config = SettingsConfigDict(frozen=True)
 
     host: str = "elasticsearch"
     port: int = 9200
@@ -63,6 +65,7 @@ class ElasticLocalSettings(BaseModel):
 
 class ElasticCloudSettings(BaseModel):
     """settings required for elastic-cloud"""
+    model_config = SettingsConfigDict(frozen=True)
 
     api_key: str
     cloud_id: str
@@ -116,7 +119,7 @@ class Settings(BaseSettings):
     dev_mode: bool = False
     superuser_email: str | None = None
 
-    model_config = SettingsConfigDict(env_file=".env", env_nested_delimiter="__", extra="allow")
+    model_config = SettingsConfigDict(env_file=".env", env_nested_delimiter="__", extra="allow", frozen=True)
 
     def elasticsearch_client(self) -> Elasticsearch:
         if isinstance(self.elastic, ElasticLocalSettings):
@@ -175,3 +178,4 @@ class Settings(BaseSettings):
     @property
     def redis_url(self) -> str:
         return f"redis://{self.redis_host}:{self.redis_port}/"
+    

--- a/redbox/models/settings.py
+++ b/redbox/models/settings.py
@@ -39,6 +39,7 @@ SUMMARISATION_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {doc
 
 class AISettings(BaseModel):
     """prompts and other AI settings"""
+
     model_config = SettingsConfigDict(frozen=True)
 
     rag_k: int = 5
@@ -52,6 +53,7 @@ class AISettings(BaseModel):
 
 class ElasticLocalSettings(BaseModel):
     """settings required for a local/ec2 instance of elastic"""
+
     model_config = SettingsConfigDict(frozen=True)
 
     host: str = "elasticsearch"
@@ -65,6 +67,7 @@ class ElasticLocalSettings(BaseModel):
 
 class ElasticCloudSettings(BaseModel):
     """settings required for elastic-cloud"""
+
     model_config = SettingsConfigDict(frozen=True)
 
     api_key: str
@@ -178,4 +181,3 @@ class Settings(BaseSettings):
     @property
     def redis_url(self) -> str:
         return f"redis://{self.redis_host}:{self.redis_port}/"
-    


### PR DESCRIPTION
## Context
We create some of our dependencies every request. This moves the semantic routes resources to be singletons but still allows overriding in tests
We also return the prompt in our streamed responses

## Changes proposed in this pull request

Use atsream chains in chat path function to make consuming llm responses simpler, we don't return the prompt and response now
Made the semantic route dependencies singletons

## Guidance to review

these could be two PRs if we want? There's a branch with just the semantic routes dependency work

## Relevant links


## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests https://github.com/i-dot-ai/redbox-copilot/actions/runs/9567410892
