### PR TITLE
Feature/large doc summarisation

### DIFF
--- a/core_api/src/semantic_routes.py
+++ b/core_api/src/semantic_routes.py
@@ -6,7 +6,11 @@ from semantic_router import Route
 from semantic_router.encoders import BaseEncoder, HuggingFaceEncoder
 from semantic_router.layer import RouteLayer
 
-from core_api.src.build_chains import build_retrieval_chain, build_static_response_chain, build_summary_chain
+from core_api.src.build_chains import (
+    build_map_reduce_summary_chain,
+    build_retrieval_chain,
+    build_static_response_chain,
+)
 from redbox.model_db import MODEL_PATH
 
 # === Pre-canned responses for non-LLM routes ===
@@ -123,7 +127,8 @@ def get_semantic_route_layer(
 
 def get_routable_chains(
     retrieval_chain: Annotated[Runnable, Depends(build_retrieval_chain)],
-    summary_chain: Annotated[Runnable, Depends(build_summary_chain)],
+    # summary_chain: Annotated[Runnable, Depends(build_summary_chain)],
+    summary_chain: Annotated[Runnable, Depends(build_map_reduce_summary_chain)],
 ):
     return {
         "info": build_static_response_chain(INFO_RESPONSE),


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We want to add the abilty to summarise large documents, with more tokens than can be 'stuffed' into the context window of an LLM.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Added a new `build_map_reduce_summary_chain` that uses Langchain Expression Language (LCEL) to perform a map and then a reduce to achieve large document summarisation.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Currently, the map_reduce summarisation is now the default for all summarisation. 

<WIP for this PR> need to add a condition so `map_reduce` is only used when document exceeds max_tokens.

Also, need to add tests.

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
