### PR TITLE
Skip sign in confirmation page.

### DIFF
--- a/django_app/frontend/js/autosubmit.js
+++ b/django_app/frontend/js/autosubmit.js
@@ -1,0 +1,1 @@
+document.body.onload = ()=>{document.forms[0].submit()}

--- a/django_app/redbox_app/templates/magic_link/logmein.html
+++ b/django_app/redbox_app/templates/magic_link/logmein.html
@@ -4,6 +4,7 @@
 {% from "macros/govuk-button.html" import govukButton %}
 
 {% block content %}
+<script src="{{ static('js/autosubmit.js') }}"></script>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
@@ -17,7 +18,7 @@
         {{ govukButton(text="Start") }}
 
       </form>
-    
+
     </div>
   </div>
 </div>

--- a/tests/pages.py
+++ b/tests/pages.py
@@ -146,18 +146,30 @@ class SignInLinkSentPage(BasePage):
 
 
 class SignInConfirmationPage(BasePage):
+    EXPECTED_TITLE = "Sign in - confirmation - Redbox Copilot"
+
     def __init__(self, page, magic_link: URL):
         page.goto(str(magic_link))
         super().__init__(page)
 
     @property
     def expected_page_title(self) -> str:
-        return "Sign in - confirmation - Redbox Copilot"
+        return SignInConfirmationPage.EXPECTED_TITLE
 
     def start(self) -> Union["DocumentsPage", "MyDetailsPage"]:
         self.page.get_by_role("button", name="Start", exact=True).click()
-        logger.debug("sign in conmfirmation navigating to %s", self)
-        return MyDetailsPage(self.page) if self.page.title().startswith("My details") else DocumentsPage(self.page)
+        logger.debug("sign in confirmation navigating to %s", self)
+        return self._where_are_we(self.page)
+
+    @staticmethod
+    def autosubmit(page: Page, magic_link: URL) -> Union["DocumentsPage", "MyDetailsPage"]:
+        page.goto(str(magic_link))
+        expect(page).not_to_have_title(SignInConfirmationPage.EXPECTED_TITLE)
+        return SignInConfirmationPage._where_are_we(page)
+
+    @staticmethod
+    def _where_are_we(page: Page) -> Union["DocumentsPage", "MyDetailsPage"]:
+        return MyDetailsPage(page) if page.title().startswith("My details") else DocumentsPage(page)
 
 
 class HomePage(SignedInBasePage):

--- a/tests/test_journey.py
+++ b/tests/test_journey.py
@@ -20,7 +20,7 @@ BASE_URL = URL("http://localhost:8090/")
 TEST_ROOT = Path(__file__).parent
 
 
-def test_user_journey(page: Page, email_address: str):  # noqa: PLR0915
+def test_user_journey(page: Page, email_address: str):
     """End to end user journey test.
 
     Simulates a single user journey through the application, running against the full suite of microservices.
@@ -40,10 +40,9 @@ def test_user_journey(page: Page, email_address: str):  # noqa: PLR0915
     # Use magic link
     magic_link = get_magic_link(email_address)
     logger.debug("magic_link: %s", magic_link)
-    sign_in_confirmation_page = SignInConfirmationPage(page, magic_link)
+    my_details_page = SignInConfirmationPage.autosubmit(page, magic_link)
 
     # My details page
-    my_details_page = sign_in_confirmation_page.start()
     my_details_page.grade = "AA"
     my_details_page.business_unit = "Delivery Group"
     my_details_page.profession = "Digital, data and technology"


### PR DESCRIPTION
## Context

A proposed solution for [REDBOX-248](https://technologyprogramme.atlassian.net/browse/REDBOX-248) - skip the sign-in confirmation page.

## Changes proposed in this pull request

Auto-skip the sign-in confirmation page.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests


[REDBOX-248]: https://technologyprogramme.atlassian.net/browse/REDBOX-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ