### PR TITLE
Send route name to the front end

### DIFF
--- a/core_api/src/runnables.py
+++ b/core_api/src/runnables.py
@@ -50,6 +50,7 @@ def map_to_chat_response(input_dict: dict):
             )
             for chunk in input_dict.get("source_documents", [])
         ],
+        route_name=input_dict["route_name"],
     )
 
 

--- a/core_api/src/semantic_routes.py
+++ b/core_api/src/semantic_routes.py
@@ -8,6 +8,7 @@ from semantic_router.layer import RouteLayer
 
 from core_api.src.build_chains import build_retrieval_chain, build_static_response_chain, build_summary_chain
 from redbox.model_db import MODEL_PATH
+from redbox.models.chat import ChatRoute
 
 # === Pre-canned responses for non-LLM routes ===
 INFO_RESPONSE = """
@@ -31,7 +32,7 @@ If you want the results to be returned in a specific format, please specify the 
 
 # === Set up the semantic router ===
 info = Route(
-    name="info",
+    name=ChatRoute.info.value,
     utterances=[
         "What is your name?",
         "Who are you?",
@@ -40,7 +41,7 @@ info = Route(
 )
 
 ability = Route(
-    name="ability",
+    name=ChatRoute.ability.value,
     utterances=[
         "What can you do?",
         "What can you do?",
@@ -56,7 +57,7 @@ ability = Route(
 )
 
 coach = Route(
-    name="coach",
+    name=ChatRoute.coach.value,
     utterances=[
         "That is not the answer I wanted",
         "Rubbish",
@@ -67,7 +68,7 @@ coach = Route(
 )
 
 gratitude = Route(
-    name="gratitude",
+    name=ChatRoute.gratitude.value,
     utterances=[
         "Thank you ever so much for your help!",
         "I'm really grateful for your assistance.",
@@ -79,7 +80,7 @@ gratitude = Route(
 )
 
 summarisation = Route(
-    name="summarisation",
+    name=ChatRoute.summarisation.value,
     utterances=[
         "I'd like to summarise the documents I've uploaded.",
         "Can you help me with summarising these documents?",
@@ -92,7 +93,7 @@ summarisation = Route(
 )
 
 extract = Route(
-    name="extract",
+    name=ChatRoute.extract.value,
     utterances=[
         "I'd like to find some information in the documents I've uploaded",
         "Can you help me identify details from these documents?",
@@ -137,11 +138,11 @@ def get_routable_chains(
     global __routable_chains  # noqa: PLW0603
     if not __routable_chains:
         __routable_chains = {
-            "info": build_static_response_chain(INFO_RESPONSE),
-            "ability": build_static_response_chain(ABILITY_RESPONSE),
-            "coach": build_static_response_chain(COACH_RESPONSE),
-            "gratitude": build_static_response_chain("You're welcome!"),
-            "retrieval": retrieval_chain,
-            "summarisation": summary_chain,
+            ChatRoute.info: build_static_response_chain(INFO_RESPONSE, ChatRoute.info),
+            ChatRoute.ability: build_static_response_chain(ABILITY_RESPONSE, ChatRoute.ability),
+            ChatRoute.coach: build_static_response_chain(COACH_RESPONSE, ChatRoute.coach),
+            ChatRoute.gratitude: build_static_response_chain("You're welcome!", ChatRoute.gratitude),
+            ChatRoute.retrieval: retrieval_chain,
+            ChatRoute.summarisation: summary_chain,
         }
     return __routable_chains

--- a/redbox/models/__init__.py
+++ b/redbox/models/__init__.py
@@ -1,4 +1,4 @@
-from redbox.models.chat import ChatMessage, ChatRequest, ChatResponse
+from redbox.models.chat import ChatMessage, ChatRequest, ChatResponse, ChatRoute
 from redbox.models.embedding import (
     EmbeddingModelInfo,
     EmbeddingResponse,
@@ -28,6 +28,7 @@ __all__ = [
     "ChatPersona",
     "ChatRequest",
     "ChatResponse",
+    "ChatRoute",
     "Chunk",
     "ChunkStatus",
     "EmbedQueueItem",

--- a/redbox/models/chat.py
+++ b/redbox/models/chat.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import Literal
 from uuid import UUID
 
@@ -61,6 +62,17 @@ class SourceDocuments(BaseModel):
     )
 
 
+class ChatRoute(StrEnum):
+    info = "info"
+    ability = "ability"
+    coach = "coach"
+    gratitude = "gratitude"
+    retrieval = "retrieval"
+    summarisation = "summarisation"
+    extract = "extract"
+    vanilla = "vanilla"
+
+
 class ChatResponse(BaseModel):
     source_documents: list[SourceDocument] | None = Field(
         description="documents retrieved to form this response", default=None
@@ -69,3 +81,4 @@ class ChatResponse(BaseModel):
         description="response text",
         examples=["The current Prime Minister of the UK is The Rt Hon. Rishi Sunak MP."],
     )
+    route_name: ChatRoute = Field(description="the conversation route taken")


### PR DESCRIPTION
## Context

Adds the changes proposed in https://github.com/i-dot-ai/redbox-copilot/pull/574 and https://github.com/i-dot-ai/redbox-copilot/pull/588 (which were both closed until other things were merged in the meantime).

## Changes proposed in this pull request

- Adds a ChatRoute class in redbox/models to consolidate route names
- returns 'route_name' in ChatResponse and in the streaming response
- tests the above
- TODO: add to e2e test

## Guidance to review

Have I tested enough? Is the ChatRoute Enum actually useful?

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-326

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
