### PR TITLE
Added vanilla route

### DIFF
--- a/core_api/src/runnables.py
+++ b/core_api/src/runnables.py
@@ -3,7 +3,12 @@ from operator import itemgetter
 from langchain.schema import StrOutputParser
 from langchain_community.chat_models import ChatLiteLLM
 from langchain_core.prompts import ChatPromptTemplate, PromptTemplate
-from langchain_core.runnables import Runnable, RunnableLambda, RunnablePassthrough, chain
+from langchain_core.runnables import (
+    Runnable,
+    RunnableLambda,
+    RunnablePassthrough,
+    chain,
+)
 from langchain_core.vectorstores import VectorStoreRetriever
 
 from core_api.src.format import format_chunks
@@ -42,11 +47,15 @@ def map_to_chat_response(input_dict: dict):
             SourceDocument(
                 page_content=chunk.text,
                 file_uuid=chunk.parent_file_uuid,
-                page_numbers=chunk.metadata.page_number
-                if isinstance(chunk.metadata.page_number, list)
-                else [chunk.metadata.page_number]
-                if chunk.metadata.page_number
-                else [],
+                page_numbers=(
+                    chunk.metadata.page_number
+                    if isinstance(chunk.metadata.page_number, list)
+                    else (
+                        [chunk.metadata.page_number]
+                        if chunk.metadata.page_number
+                        else []
+                    )
+                ),
             )
             for chunk in input_dict.get("source_documents", [])
         ],
@@ -78,7 +87,9 @@ def make_chat_runnable(system_prompt: str, llm: ChatLiteLLM) -> Runnable:
     )
 
 
-def make_stuff_document_runnable(system_prompt: str, question_prompt: str, llm: ChatLiteLLM) -> Runnable:
+def make_stuff_document_runnable(
+    system_prompt: str, question_prompt: str, llm: ChatLiteLLM
+) -> Runnable:
     """Takes a system prompt and LLM returns a stuff document runnable.
 
     Runnable takes input of a dict keyed to question, messages and documents.
@@ -88,7 +99,10 @@ def make_stuff_document_runnable(system_prompt: str, question_prompt: str, llm: 
     chat_history = [
         ("system", system_prompt),
         ("placeholder", "{messages}"),
-        ("user", "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "),
+        (
+            "user",
+            "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: ",
+        ),
     ]
 
     return (
@@ -153,7 +167,10 @@ def make_condense_rag_runnable(
     """
     chat_history = [
         ("system", system_prompt),
-        ("user", "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "),
+        (
+            "user",
+            "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: ",
+        ),
     ]
 
     prompt = ChatPromptTemplate.from_messages(chat_history)

--- a/core_api/src/runnables.py
+++ b/core_api/src/runnables.py
@@ -50,11 +50,7 @@ def map_to_chat_response(input_dict: dict):
                 page_numbers=(
                     chunk.metadata.page_number
                     if isinstance(chunk.metadata.page_number, list)
-                    else (
-                        [chunk.metadata.page_number]
-                        if chunk.metadata.page_number
-                        else []
-                    )
+                    else ([chunk.metadata.page_number] if chunk.metadata.page_number else [])
                 ),
             )
             for chunk in input_dict.get("source_documents", [])
@@ -87,9 +83,7 @@ def make_chat_runnable(system_prompt: str, llm: ChatLiteLLM) -> Runnable:
     )
 
 
-def make_stuff_document_runnable(
-    system_prompt: str, question_prompt: str, llm: ChatLiteLLM
-) -> Runnable:
+def make_stuff_document_runnable(system_prompt: str, question_prompt: str, llm: ChatLiteLLM) -> Runnable:
     """Takes a system prompt and LLM returns a stuff document runnable.
 
     Runnable takes input of a dict keyed to question, messages and documents.

--- a/core_api/src/semantic_routes.py
+++ b/core_api/src/semantic_routes.py
@@ -156,14 +156,10 @@ def get_semantic_routing_encoder():
     return __semantic_routing_encoder
 
 
-def get_semantic_route_layer(
-    routes: Annotated[list[Route], Depends(get_semantic_routes)]
-):
+def get_semantic_route_layer(routes: Annotated[list[Route], Depends(get_semantic_routes)]):
     global __semantic_route_layer  # noqa: PLW0603
     if not __semantic_route_layer:
-        __semantic_route_layer = RouteLayer(
-            encoder=get_semantic_routing_encoder(), routes=routes
-        )
+        __semantic_route_layer = RouteLayer(encoder=get_semantic_routing_encoder(), routes=routes)
     return __semantic_route_layer
 
 
@@ -176,15 +172,9 @@ def get_routable_chains(
     if not __routable_chains:
         __routable_chains = {
             ChatRoute.info: build_static_response_chain(INFO_RESPONSE, ChatRoute.info),
-            ChatRoute.ability: build_static_response_chain(
-                ABILITY_RESPONSE, ChatRoute.ability
-            ),
-            ChatRoute.coach: build_static_response_chain(
-                COACH_RESPONSE, ChatRoute.coach
-            ),
-            ChatRoute.gratitude: build_static_response_chain(
-                "You're welcome!", ChatRoute.gratitude
-            ),
+            ChatRoute.ability: build_static_response_chain(ABILITY_RESPONSE, ChatRoute.ability),
+            ChatRoute.coach: build_static_response_chain(COACH_RESPONSE, ChatRoute.coach),
+            ChatRoute.gratitude: build_static_response_chain("You're welcome!", ChatRoute.gratitude),
             ChatRoute.vanilla: vanilla_chain,
             ChatRoute.retrieval: retrieval_chain,
             ChatRoute.summarisation: summary_chain,

--- a/redbox/models/settings.py
+++ b/redbox/models/settings.py
@@ -10,6 +10,8 @@ logging.basicConfig(level=logging.INFO)
 log = logging.getLogger()
 
 
+VANILLA_SYSTEM_PROMPT = "You are an AI assistant called Redbox tasked with answering questions and providing information objectively."
+
 RETRIEVAL_SYSTEM_PROMPT = (
     "Given the following conversation and extracted parts of a long document and a question, create a final answer. \n"
     "If you don't know the answer, just say that you don't know. Don't try to make up an answer. "
@@ -50,16 +52,26 @@ REDUCE_SYSTEM_PROMPT = (
     "4) Maintain the original context and meaning.\n"
 )
 
-RETRIEVAL_QUESTION_PROMPT = "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
+VANILLA_QUESTION_PROMPT = "{question}\n=========\n Response: "
+
+RETRIEVAL_QUESTION_PROMPT = (
+    "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
+)
 
 
-SUMMARISATION_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
+SUMMARISATION_QUESTION_PROMPT = (
+    "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
+)
 
 
-MAP_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
+MAP_QUESTION_PROMPT = (
+    "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
+)
 
 
-REDUCE_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
+REDUCE_QUESTION_PROMPT = (
+    "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
+)
 
 
 class AISettings(BaseModel):
@@ -71,6 +83,8 @@ class AISettings(BaseModel):
     rag_num_candidates: int = 10
     rag_desired_chunk_size: int = 300
     max_tokens: int = 20_000
+    vanilla_system_prompt: str = VANILLA_SYSTEM_PROMPT
+    vanilla_question_prompt: str = VANILLA_QUESTION_PROMPT
     retrieval_system_prompt: str = RETRIEVAL_SYSTEM_PROMPT
     retrieval_question_prompt: str = RETRIEVAL_QUESTION_PROMPT
     summarisation_system_prompt: str = SUMMARISATION_SYSTEM_PROMPT
@@ -152,7 +166,9 @@ class Settings(BaseSettings):
     dev_mode: bool = False
     superuser_email: str | None = None
 
-    model_config = SettingsConfigDict(env_file=".env", env_nested_delimiter="__", extra="allow", frozen=True)
+    model_config = SettingsConfigDict(
+        env_file=".env", env_nested_delimiter="__", extra="allow", frozen=True
+    )
 
     def elasticsearch_client(self) -> Elasticsearch:
         if isinstance(self.elastic, ElasticLocalSettings):
@@ -173,7 +189,9 @@ class Settings(BaseSettings):
         log.info("Cloud ID = %s", self.elastic.cloud_id)
         log.info("Elastic Cloud API Key = %s", self.elastic.api_key)
 
-        return Elasticsearch(cloud_id=self.elastic.cloud_id, api_key=self.elastic.api_key)
+        return Elasticsearch(
+            cloud_id=self.elastic.cloud_id, api_key=self.elastic.api_key
+        )
 
     def s3_client(self):
         if self.object_store == "minio":

--- a/redbox/models/settings.py
+++ b/redbox/models/settings.py
@@ -10,7 +10,9 @@ logging.basicConfig(level=logging.INFO)
 log = logging.getLogger()
 
 
-VANILLA_SYSTEM_PROMPT = "You are an AI assistant called Redbox tasked with answering questions and providing information objectively."
+VANILLA_SYSTEM_PROMPT = (
+    "You are an AI assistant called Redbox tasked with answering questions and providing information objectively."
+)
 
 RETRIEVAL_SYSTEM_PROMPT = (
     "Given the following conversation and extracted parts of a long document and a question, create a final answer. \n"
@@ -54,24 +56,16 @@ REDUCE_SYSTEM_PROMPT = (
 
 VANILLA_QUESTION_PROMPT = "{question}\n=========\n Response: "
 
-RETRIEVAL_QUESTION_PROMPT = (
-    "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
-)
+RETRIEVAL_QUESTION_PROMPT = "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
 
 
-SUMMARISATION_QUESTION_PROMPT = (
-    "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
-)
+SUMMARISATION_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
 
 
-MAP_QUESTION_PROMPT = (
-    "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
-)
+MAP_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
 
 
-REDUCE_QUESTION_PROMPT = (
-    "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
-)
+REDUCE_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
 
 
 class AISettings(BaseModel):
@@ -166,9 +160,7 @@ class Settings(BaseSettings):
     dev_mode: bool = False
     superuser_email: str | None = None
 
-    model_config = SettingsConfigDict(
-        env_file=".env", env_nested_delimiter="__", extra="allow", frozen=True
-    )
+    model_config = SettingsConfigDict(env_file=".env", env_nested_delimiter="__", extra="allow", frozen=True)
 
     def elasticsearch_client(self) -> Elasticsearch:
         if isinstance(self.elastic, ElasticLocalSettings):
@@ -189,9 +181,7 @@ class Settings(BaseSettings):
         log.info("Cloud ID = %s", self.elastic.cloud_id)
         log.info("Elastic Cloud API Key = %s", self.elastic.api_key)
 
-        return Elasticsearch(
-            cloud_id=self.elastic.cloud_id, api_key=self.elastic.api_key
-        )
+        return Elasticsearch(cloud_id=self.elastic.cloud_id, api_key=self.elastic.api_key)
 
     def s3_client(self):
         if self.object_store == "minio":


### PR DESCRIPTION
## Context

Redbox currently doesn't handle off topic conversations well, where normal chat services do.

## Changes proposed in this pull request

I've added a vanilla route which aims to act as broad collection of phrases that aren't directly information seeking. This then routes to a new chain that allows a minimally prompted LLM to respond directly with the full chat history.

## Guidance to review

Example below on asking Redbox to do something odd.

![Screenshot 2024-06-24 at 09 42 02](https://github.com/i-dot-ai/redbox-copilot/assets/146714503/ac798a45-f40c-44e6-8a7e-50b35e9a958b)

To review, load up UX and try a few requests into the model, and some RAG ones to check intersection of routes.

The routing will require refinement with more utterances!

## Relevant links

## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
