### PR TITLE
Add parallel processing to `map` step of map reduce summarisation

### DIFF
--- a/core_api/src/build_chains.py
+++ b/core_api/src/build_chains.py
@@ -34,9 +34,7 @@ def build_vanilla_chain(
     env: Annotated[Settings, Depends(dependencies.get_env)],
 ) -> Runnable:
     return (
-        make_chat_prompt_from_messages_runnable(
-            env.ai.vanilla_system_prompt, env.ai.vanilla_question_prompt
-        )
+        make_chat_prompt_from_messages_runnable(env.ai.vanilla_system_prompt, env.ai.vanilla_question_prompt)
         | llm
         | {
             "response": StrOutputParser(),
@@ -53,9 +51,7 @@ def build_retrieval_chain(
     return (
         RunnablePassthrough.assign(documents=retriever)
         | RunnablePassthrough.assign(
-            formatted_documents=(
-                RunnablePassthrough() | itemgetter("documents") | format_chunks
-            )
+            formatted_documents=(RunnablePassthrough() | itemgetter("documents") | format_chunks)
         )
         | {
             "response": make_chat_prompt_from_messages_runnable(
@@ -71,9 +67,7 @@ def build_retrieval_chain(
 
 def build_summary_chain(
     llm: Annotated[ChatLiteLLM, Depends(dependencies.get_llm)],
-    storage_handler: Annotated[
-        ElasticsearchStorageHandler, Depends(dependencies.get_storage_handler)
-    ],
+    storage_handler: Annotated[ElasticsearchStorageHandler, Depends(dependencies.get_storage_handler)],
     env: Annotated[Settings, Depends(dependencies.get_env)],
 ) -> Runnable:
     def make_document_context(input_dict):
@@ -93,15 +87,11 @@ def build_summary_chain(
 
         documents_trunc = documents[:doc_token_sum_limit_index]
         if len(documents) < doc_token_sum_limit_index:
-            log.info(
-                "Documents were longer than 20k tokens. Truncating to the first 20k."
-            )
+            log.info("Documents were longer than 20k tokens. Truncating to the first 20k.")
         return documents_trunc
 
     return (
-        RunnablePassthrough.assign(
-            documents=(make_document_context | RunnableLambda(format_chunks))
-        )
+        RunnablePassthrough.assign(documents=(make_document_context | RunnableLambda(format_chunks)))
         | make_chat_prompt_from_messages_runnable(
             env.ai.summarisation_system_prompt, env.ai.summarisation_question_prompt
         )
@@ -112,9 +102,7 @@ def build_summary_chain(
 
 def build_map_reduce_summary_chain(
     llm: Annotated[ChatLiteLLM, Depends(dependencies.get_llm)],
-    storage_handler: Annotated[
-        ElasticsearchStorageHandler, Depends(dependencies.get_storage_handler)
-    ],
+    storage_handler: Annotated[ElasticsearchStorageHandler, Depends(dependencies.get_storage_handler)],
     env: Annotated[Settings, Depends(dependencies.get_env)],
 ) -> Runnable:
     def make_document_context(input_dict: dict):
@@ -136,9 +124,7 @@ def build_map_reduce_summary_chain(
         system_map_prompt = env.ai.map_system_prompt
         prompt_template = PromptTemplate.from_template(env.ai.map_question_prompt)
 
-        formatted_map_question_prompt = prompt_template.format(
-            question=input_dict["question"]
-        )
+        formatted_map_question_prompt = prompt_template.format(question=input_dict["question"])
 
         map_prompt = ChatPromptTemplate.from_messages(
             [
@@ -160,9 +146,7 @@ def build_map_reduce_summary_chain(
     return (
         RunnablePassthrough.assign(documents=make_document_context)
         | map_operation
-        | make_chat_prompt_from_messages_runnable(
-            env.ai.reduce_system_prompt, env.ai.reduce_question_prompt
-        )
+        | make_chat_prompt_from_messages_runnable(env.ai.reduce_system_prompt, env.ai.reduce_question_prompt)
         | llm
         | {
             "response": StrOutputParser(),
@@ -173,10 +157,7 @@ def build_map_reduce_summary_chain(
 
 def build_static_response_chain(prompt_template, route_name) -> Runnable:
     return RunnablePassthrough.assign(
-        response=(
-            ChatPromptTemplate.from_template(prompt_template)
-            | RunnableLambda(lambda p: p.messages[0].content)
-        ),
+        response=(ChatPromptTemplate.from_template(prompt_template) | RunnableLambda(lambda p: p.messages[0].content)),
         source_documents=RunnableLambda(lambda _: []),
         route_name=RunnableLambda(lambda _: route_name.value),
     )

--- a/core_api/src/build_chains.py
+++ b/core_api/src/build_chains.py
@@ -4,10 +4,17 @@ from typing import Annotated
 
 import numpy as np
 from fastapi import Depends
+from langchain.prompts import PromptTemplate
 from langchain.schema import StrOutputParser
 from langchain_community.chat_models import ChatLiteLLM
 from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.runnables import Runnable, RunnableLambda, RunnablePassthrough
+from langchain_core.runnables import (
+    Runnable,
+    RunnableLambda,
+    RunnablePassthrough,
+    chain,
+)
+from langchain_core.runnables.config import RunnableConfig
 from langchain_core.vectorstores import VectorStoreRetriever
 
 from core_api.src import dependencies
@@ -99,7 +106,7 @@ def build_map_reduce_summary_chain(
     env: Annotated[Settings, Depends(dependencies.get_env)],
 ) -> Runnable:
     def make_document_context(input_dict: dict):
-        documents: list[str] = []
+        documents: list[Chunk] = []
         for selected_file in input_dict["file_uuids"]:
             chunks = get_file_chunked_to_tokens(
                 file_uuid=selected_file,
@@ -107,24 +114,38 @@ def build_map_reduce_summary_chain(
                 storage_handler=storage_handler,
                 max_tokens=env.ai.max_tokens,
             )
-            documents += [chunk.text for chunk in chunks]
+            documents += chunks
 
+        input_dict["documents"] = documents
         return documents
 
-    map_step = (
-        RunnablePassthrough.assign(documents=make_document_context)
-        | make_chat_prompt_from_messages_runnable(env.ai.map_system_prompt, env.ai.map_question_prompt)
-        | llm
-        | StrOutputParser()
-    )
+    @chain
+    def map_operation(input_dict):
+        system_map_prompt = env.ai.map_system_prompt
+        prompt_template = PromptTemplate.from_template(env.ai.map_question_prompt)
 
-    def map_operation(input_dict: dict):
-        output = map_step.invoke(input_dict)
-        input_dict["documents"] = output
+        formatted_map_question_prompt = prompt_template.format(question=input_dict["question"])
+
+        map_prompt = ChatPromptTemplate.from_messages(
+            [
+                ("system", system_map_prompt),
+                ("human", formatted_map_question_prompt + env.ai.map_document_prompt),
+            ]
+        )
+
+        documents = [chunk.text for chunk in input_dict["documents"]]
+
+        map_summaries = (map_prompt | llm | StrOutputParser()).batch(
+            documents, config=RunnableConfig(max_concurrency=128)
+        )
+
+        summaries = " ; ".join(map_summaries)
+        input_dict["summaries"] = summaries
         return input_dict
 
     return (
-        map_operation
+        RunnablePassthrough.assign(documents=make_document_context)
+        | map_operation
         | make_chat_prompt_from_messages_runnable(env.ai.reduce_system_prompt, env.ai.reduce_question_prompt)
         | llm
         | {
@@ -132,8 +153,6 @@ def build_map_reduce_summary_chain(
             "route_name": RunnableLambda(lambda _: ChatRoute.summarise.value),
         }
     )
-    #     | {"response": StrOutputParser()}
-    # )
 
 
 def build_static_response_chain(prompt_template, route_name) -> Runnable:

--- a/core_api/src/build_chains.py
+++ b/core_api/src/build_chains.py
@@ -34,7 +34,9 @@ def build_vanilla_chain(
     env: Annotated[Settings, Depends(dependencies.get_env)],
 ) -> Runnable:
     return (
-        make_chat_prompt_from_messages_runnable(env.ai.vanilla_system_prompt, env.ai.vanilla_question_prompt)
+        make_chat_prompt_from_messages_runnable(
+            env.ai.vanilla_system_prompt, env.ai.vanilla_question_prompt
+        )
         | llm
         | {
             "response": StrOutputParser(),
@@ -51,7 +53,9 @@ def build_retrieval_chain(
     return (
         RunnablePassthrough.assign(documents=retriever)
         | RunnablePassthrough.assign(
-            formatted_documents=(RunnablePassthrough() | itemgetter("documents") | format_chunks)
+            formatted_documents=(
+                RunnablePassthrough() | itemgetter("documents") | format_chunks
+            )
         )
         | {
             "response": make_chat_prompt_from_messages_runnable(
@@ -67,7 +71,9 @@ def build_retrieval_chain(
 
 def build_summary_chain(
     llm: Annotated[ChatLiteLLM, Depends(dependencies.get_llm)],
-    storage_handler: Annotated[ElasticsearchStorageHandler, Depends(dependencies.get_storage_handler)],
+    storage_handler: Annotated[
+        ElasticsearchStorageHandler, Depends(dependencies.get_storage_handler)
+    ],
     env: Annotated[Settings, Depends(dependencies.get_env)],
 ) -> Runnable:
     def make_document_context(input_dict):
@@ -81,17 +87,21 @@ def build_summary_chain(
             documents += chunks
 
         # right now, can only handle a single document so we manually truncate
-        max_tokens = (env.ai.max_tokens,)
+        max_tokens = (env.ai.summarisation_chunk_max_tokens,)
         doc_token_sum = np.cumsum([doc.token_count for doc in documents])
         doc_token_sum_limit_index = len([i for i in doc_token_sum if i < max_tokens])
 
         documents_trunc = documents[:doc_token_sum_limit_index]
         if len(documents) < doc_token_sum_limit_index:
-            log.info("Documents were longer than 20k tokens. Truncating to the first 20k.")
+            log.info(
+                "Documents were longer than 20k tokens. Truncating to the first 20k."
+            )
         return documents_trunc
 
     return (
-        RunnablePassthrough.assign(documents=(make_document_context | RunnableLambda(format_chunks)))
+        RunnablePassthrough.assign(
+            documents=(make_document_context | RunnableLambda(format_chunks))
+        )
         | make_chat_prompt_from_messages_runnable(
             env.ai.summarisation_system_prompt, env.ai.summarisation_question_prompt
         )
@@ -102,7 +112,9 @@ def build_summary_chain(
 
 def build_map_reduce_summary_chain(
     llm: Annotated[ChatLiteLLM, Depends(dependencies.get_llm)],
-    storage_handler: Annotated[ElasticsearchStorageHandler, Depends(dependencies.get_storage_handler)],
+    storage_handler: Annotated[
+        ElasticsearchStorageHandler, Depends(dependencies.get_storage_handler)
+    ],
     env: Annotated[Settings, Depends(dependencies.get_env)],
 ) -> Runnable:
     def make_document_context(input_dict: dict):
@@ -112,7 +124,7 @@ def build_map_reduce_summary_chain(
                 file_uuid=selected_file,
                 user_uuid=input_dict["user_uuid"],
                 storage_handler=storage_handler,
-                max_tokens=env.ai.max_tokens,
+                max_tokens=env.ai.summarisation_chunk_max_tokens,
             )
             documents += chunks
 
@@ -124,7 +136,9 @@ def build_map_reduce_summary_chain(
         system_map_prompt = env.ai.map_system_prompt
         prompt_template = PromptTemplate.from_template(env.ai.map_question_prompt)
 
-        formatted_map_question_prompt = prompt_template.format(question=input_dict["question"])
+        formatted_map_question_prompt = prompt_template.format(
+            question=input_dict["question"]
+        )
 
         map_prompt = ChatPromptTemplate.from_messages(
             [
@@ -146,7 +160,9 @@ def build_map_reduce_summary_chain(
     return (
         RunnablePassthrough.assign(documents=make_document_context)
         | map_operation
-        | make_chat_prompt_from_messages_runnable(env.ai.reduce_system_prompt, env.ai.reduce_question_prompt)
+        | make_chat_prompt_from_messages_runnable(
+            env.ai.reduce_system_prompt, env.ai.reduce_question_prompt
+        )
         | llm
         | {
             "response": StrOutputParser(),
@@ -157,7 +173,10 @@ def build_map_reduce_summary_chain(
 
 def build_static_response_chain(prompt_template, route_name) -> Runnable:
     return RunnablePassthrough.assign(
-        response=(ChatPromptTemplate.from_template(prompt_template) | RunnableLambda(lambda p: p.messages[0].content)),
+        response=(
+            ChatPromptTemplate.from_template(prompt_template)
+            | RunnableLambda(lambda p: p.messages[0].content)
+        ),
         source_documents=RunnableLambda(lambda _: []),
         route_name=RunnableLambda(lambda _: route_name.value),
     )

--- a/core_api/src/build_chains.py
+++ b/core_api/src/build_chains.py
@@ -96,7 +96,10 @@ def build_summary_chain(
             env.ai.summarisation_system_prompt, env.ai.summarisation_question_prompt
         )
         | llm
-        | {"response": StrOutputParser(), "route_name": RunnableLambda(lambda _: ChatRoute.summarise.value)}
+        | {
+            "response": StrOutputParser(),
+            "route_name": RunnableLambda(lambda _: ChatRoute.summarise.value),
+        }
     )
 
 
@@ -136,7 +139,8 @@ def build_map_reduce_summary_chain(
         documents = [chunk.text for chunk in input_dict["documents"]]
 
         map_summaries = (map_prompt | llm | StrOutputParser()).batch(
-            documents, config=RunnableConfig(max_concurrency=128)
+            documents,
+            config=RunnableConfig(max_concurrency=env.ai.summarisation_max_concurrency),
         )
 
         summaries = " ; ".join(map_summaries)

--- a/redbox/models/file.py
+++ b/redbox/models/file.py
@@ -129,9 +129,6 @@ class Chunk(PersistableModel):
     def token_count(self) -> int:
         return len(encoding.encode(self.text))
 
-    def __iter__(self):
-        return iter(self.text)
-
 
 class ChunkStatus(BaseModel):
     """Status of a chunk of a file."""

--- a/redbox/models/file.py
+++ b/redbox/models/file.py
@@ -129,6 +129,9 @@ class Chunk(PersistableModel):
     def token_count(self) -> int:
         return len(encoding.encode(self.text))
 
+    def __iter__(self):
+        return iter(self.text)
+
 
 class ChunkStatus(BaseModel):
     """Status of a chunk of a file."""

--- a/redbox/models/settings.py
+++ b/redbox/models/settings.py
@@ -10,7 +10,9 @@ logging.basicConfig(level=logging.INFO)
 log = logging.getLogger()
 
 
-VANILLA_SYSTEM_PROMPT = "You are an AI assistant called Redbox tasked with answering questions and providing information objectively."
+VANILLA_SYSTEM_PROMPT = (
+    "You are an AI assistant called Redbox tasked with answering questions and providing information objectively."
+)
 
 RETRIEVAL_SYSTEM_PROMPT = (
     "Given the following conversation and extracted parts of a long document and a question, create a final answer. \n"
@@ -54,23 +56,17 @@ REDUCE_SYSTEM_PROMPT = (
 
 VANILLA_QUESTION_PROMPT = "{question}\n=========\n Response: "
 
-RETRIEVAL_QUESTION_PROMPT = (
-    "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
-)
+RETRIEVAL_QUESTION_PROMPT = "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
 
 
-SUMMARISATION_QUESTION_PROMPT = (
-    "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
-)
+SUMMARISATION_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
 
 MAP_QUESTION_PROMPT = "Question: {question}. "
 
 MAP_DOCUMENT_PROMPT = "\n\n Documents: \n\n {documents} \n\n Answer: "
 
 
-REDUCE_QUESTION_PROMPT = (
-    "Question: {question}. \n\n Documents: \n\n {summaries} \n\n Answer: "
-)
+REDUCE_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {summaries} \n\n Answer: "
 
 
 class AISettings(BaseModel):
@@ -173,9 +169,7 @@ class Settings(BaseSettings):
     dev_mode: bool = False
     superuser_email: str | None = None
 
-    model_config = SettingsConfigDict(
-        env_file=".env", env_nested_delimiter="__", extra="allow", frozen=True
-    )
+    model_config = SettingsConfigDict(env_file=".env", env_nested_delimiter="__", extra="allow", frozen=True)
 
     def elasticsearch_client(self) -> Elasticsearch:
         if isinstance(self.elastic, ElasticLocalSettings):
@@ -196,9 +190,7 @@ class Settings(BaseSettings):
         log.info("Cloud ID = %s", self.elastic.cloud_id)
         log.info("Elastic Cloud API Key = %s", self.elastic.api_key)
 
-        return Elasticsearch(
-            cloud_id=self.elastic.cloud_id, api_key=self.elastic.api_key
-        )
+        return Elasticsearch(cloud_id=self.elastic.cloud_id, api_key=self.elastic.api_key)
 
     def s3_client(self):
         if self.object_store == "minio":

--- a/redbox/models/settings.py
+++ b/redbox/models/settings.py
@@ -10,9 +10,7 @@ logging.basicConfig(level=logging.INFO)
 log = logging.getLogger()
 
 
-VANILLA_SYSTEM_PROMPT = (
-    "You are an AI assistant called Redbox tasked with answering questions and providing information objectively."
-)
+VANILLA_SYSTEM_PROMPT = "You are an AI assistant called Redbox tasked with answering questions and providing information objectively."
 
 RETRIEVAL_SYSTEM_PROMPT = (
     "Given the following conversation and extracted parts of a long document and a question, create a final answer. \n"
@@ -56,17 +54,23 @@ REDUCE_SYSTEM_PROMPT = (
 
 VANILLA_QUESTION_PROMPT = "{question}\n=========\n Response: "
 
-RETRIEVAL_QUESTION_PROMPT = "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
+RETRIEVAL_QUESTION_PROMPT = (
+    "{question} \n=========\n{formatted_documents}\n=========\nFINAL ANSWER: "
+)
 
 
-SUMMARISATION_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
+SUMMARISATION_QUESTION_PROMPT = (
+    "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
+)
 
 MAP_QUESTION_PROMPT = "Question: {question}. "
 
 MAP_DOCUMENT_PROMPT = "\n\n Documents: \n\n {documents} \n\n Answer: "
 
 
-REDUCE_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {summaries} \n\n Answer: "
+REDUCE_QUESTION_PROMPT = (
+    "Question: {question}. \n\n Documents: \n\n {summaries} \n\n Answer: "
+)
 
 
 class AISettings(BaseModel):
@@ -77,7 +81,7 @@ class AISettings(BaseModel):
     rag_k: int = 5
     rag_num_candidates: int = 10
     rag_desired_chunk_size: int = 300
-    max_tokens: int = 20_000
+    summarisation_chunk_max_tokens: int = 20_000
     vanilla_system_prompt: str = VANILLA_SYSTEM_PROMPT
     vanilla_question_prompt: str = VANILLA_QUESTION_PROMPT
     retrieval_system_prompt: str = RETRIEVAL_SYSTEM_PROMPT
@@ -169,7 +173,9 @@ class Settings(BaseSettings):
     dev_mode: bool = False
     superuser_email: str | None = None
 
-    model_config = SettingsConfigDict(env_file=".env", env_nested_delimiter="__", extra="allow", frozen=True)
+    model_config = SettingsConfigDict(
+        env_file=".env", env_nested_delimiter="__", extra="allow", frozen=True
+    )
 
     def elasticsearch_client(self) -> Elasticsearch:
         if isinstance(self.elastic, ElasticLocalSettings):
@@ -190,7 +196,9 @@ class Settings(BaseSettings):
         log.info("Cloud ID = %s", self.elastic.cloud_id)
         log.info("Elastic Cloud API Key = %s", self.elastic.api_key)
 
-        return Elasticsearch(cloud_id=self.elastic.cloud_id, api_key=self.elastic.api_key)
+        return Elasticsearch(
+            cloud_id=self.elastic.cloud_id, api_key=self.elastic.api_key
+        )
 
     def s3_client(self):
         if self.object_store == "minio":

--- a/redbox/models/settings.py
+++ b/redbox/models/settings.py
@@ -78,6 +78,7 @@ class AISettings(BaseModel):
     rag_num_candidates: int = 10
     rag_desired_chunk_size: int = 300
     summarisation_chunk_max_tokens: int = 20_000
+    summarisation_max_concurrency: int = 128
     vanilla_system_prompt: str = VANILLA_SYSTEM_PROMPT
     vanilla_question_prompt: str = VANILLA_QUESTION_PROMPT
     retrieval_system_prompt: str = RETRIEVAL_SYSTEM_PROMPT

--- a/redbox/models/settings.py
+++ b/redbox/models/settings.py
@@ -61,11 +61,12 @@ RETRIEVAL_QUESTION_PROMPT = "{question} \n=========\n{formatted_documents}\n====
 
 SUMMARISATION_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
 
+MAP_QUESTION_PROMPT = "Question: {question}. "
 
-MAP_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
+MAP_DOCUMENT_PROMPT = "\n\n Documents: \n\n {documents} \n\n Answer: "
 
 
-REDUCE_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {documents} \n\n Answer: "
+REDUCE_QUESTION_PROMPT = "Question: {question}. \n\n Documents: \n\n {summaries} \n\n Answer: "
 
 
 class AISettings(BaseModel):
@@ -85,6 +86,7 @@ class AISettings(BaseModel):
     summarisation_question_prompt: str = SUMMARISATION_QUESTION_PROMPT
     map_system_prompt: str = MAP_SYSTEM_PROMPT
     map_question_prompt: str = MAP_QUESTION_PROMPT
+    map_document_prompt: str = MAP_DOCUMENT_PROMPT
     reduce_system_prompt: str = REDUCE_SYSTEM_PROMPT
     reduce_question_prompt: str = REDUCE_QUESTION_PROMPT
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Before this change, the map step of map reduce summarisation, used for large document summarisation, was not happing in parallel. The code needed to be updated to allow the parallele summarisation of large documents into smaller summaries using LCEL `batch`.

`batch` only takes a list as input, so I needed to split the question prompt into `map_question_prompt`, which is populated with the question and chat_history before being passed to the `map_operation` and then the `map_document_prompt` which is populated when running `batch`.

## Changes proposed in this pull request
- Updated `build_map_reduce_summary_chain` to allow for `batch` processing
- Made `Chunk` model iterable
- Renamed `max_tokens` in env var AI Settings to `summarisation_chunk_max_tokens` to better describe what it does. `max_tokens` is already an overloaded term.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Check you are happy with how I have structured `build_map_reduce_summary_chain`.

## Relevant links


## Things to check

- [x] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests
