### PR TITLE
bugfix/vanilla->chat

### DIFF
--- a/core_api/src/build_chains.py
+++ b/core_api/src/build_chains.py
@@ -38,7 +38,7 @@ def build_vanilla_chain(
         | llm
         | {
             "response": StrOutputParser(),
-            "route_name": RunnableLambda(lambda _: ChatRoute.vanilla.value),
+            "route_name": RunnableLambda(lambda _: ChatRoute.chat.value),
         }
     )
 


### PR DESCRIPTION
## Context

I am fixing an attribute error where `ChatRoute.vanilla` should be `ChatRoute.chat`

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
