### PR TITLE
collect citations for non-streamed responses

### DIFF
--- a/django_app/redbox_app/redbox_core/client.py
+++ b/django_app/redbox_app/redbox_core/client.py
@@ -46,6 +46,7 @@ def s3_client():
 @dataclass(frozen=True)
 class CoreChatResponseDoc:
     file_uuid: str
+    page_content: str
 
 
 @dataclass_json(undefined=Undefined.EXCLUDE)

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -171,9 +171,7 @@ class ChatConsumer(AsyncWebsocketConsumer):
         uuids = [doc.file_uuid for doc in docs]
         files = File.objects.filter(core_file_uuid__in=uuids, user=user)
 
-        return files, [
-            (file, [doc for doc in docs if doc.file_uuid == file.core_file_uuid]) for file in files
-        ]
+        return files, [(file, [doc for doc in docs if doc.file_uuid == file.core_file_uuid]) for file in files]
 
     @staticmethod
     @database_sync_to_async

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -67,7 +67,7 @@
               role = message.role,
               route = message.route,
               text = message.text,
-              sources = message.source_files.all()
+              sources = message.source_files.distinct()
             ) }}
           {% endfor %}
 


### PR DESCRIPTION
## Context

Extends https://github.com/i-dot-ai/redbox-copilot/pull/641 to collect for non-streamed chat.

## Changes proposed in this pull request
Add citations to Django db during non-streamed chat.

## Guidance to review
Turn off streaming, and test chatting. You should be able to see Citations in Django admin

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-367

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests
