### PR TITLE
Add Django admin command for reupload

### DIFF
--- a/core_api/src/routes/file.py
+++ b/core_api/src/routes/file.py
@@ -193,7 +193,6 @@ def delete_file(file_uuid: UUID, user_uuid: Annotated[UUID, Depends(get_user_uui
     if file.creator_user_uuid != user_uuid:
         return file_not_found_response(file_uuid=file_uuid)
 
-    s3.delete_object(Bucket=env.bucket_name, Key=file.key)
     storage_handler.delete_item(file)
 
     chunks = storage_handler.get_file_chunks(file.uuid, user_uuid)

--- a/core_api/tests/routes/test_file.py
+++ b/core_api/tests/routes/test_file.py
@@ -91,8 +91,6 @@ def test_delete_file(s3_client, app_client, elasticsearch_storage_handler, chunk
     elasticsearch_storage_handler.refresh()
 
     # check assets dont exist
-    with pytest.raises(s3_client.exceptions.NoSuchKey):
-        s3_client.get_object(Bucket=env.bucket_name, Key=chunked_file.key)
 
     with pytest.raises(NotFoundError):
         elasticsearch_storage_handler.read_item(item_uuid=chunked_file.uuid, model_type="file")


### PR DESCRIPTION
## Context
As we've improved our chunking and embedding tasks and the re-embedding is a breaking change, we will need to reupload all user files to the core-api for re-processing.

## Changes proposed in this pull request
Adds a new command in Django Admin to re-upload selected files to the core-api.

Also removes a duplicate 'remove from s3' call in core-api

## Guidance to review
Try it out locally:
* Run the command from Django Admin
* Confirm that the files are usable in a chat on Django
* Confirm that deleting a file from Django removes it from MinIO

## Relevant links
https://github.com/i-dot-ai/redbox-copilot/actions/runs/9711381642

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
