### PR TITLE
Do not show link to deleted files.

### DIFF
--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -19,7 +19,7 @@
                   {% if source.get_status_text() == "Complete" %}
                     <a class="iai-chat-bubbles__sources-link govuk-link" href="{{ source.url }}">{{ source.original_file_name }}</a>
                   {% else %}
-                    <p class="iai-chat-bubbles__sources-link">{{ source.original_file_name }}</p>
+                    <span class="iai-chat-bubbles__sources-link">{{ source.original_file_name }}</span>
                   {% endif %}
                 </li>
                 {% endfor %}

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -16,7 +16,11 @@
             <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
                 {% for source in sources %}
                 <li class="govuk-!-margin-bottom-0">
+                  {% if source.get_status_text() == "Complete" %}
                     <a class="iai-chat-bubbles__sources-link govuk-link" href="{{ source.url }}">{{ source.original_file_name }}</a>
+                  {% else %}
+                    <p class="iai-chat-bubbles__sources-link">{{ source.original_file_name }}</p>
+                  {% endif %}
                 </li>
                 {% endfor %}
             </ul>


### PR DESCRIPTION
## Context

Where an existing chat references a source file which ha since been deleted, there will be no file to link to.

We'd still like to show the file name for context with the response. 

## Changes proposed in this pull request

![Screenshot 2024-06-28 at 11 26 10](https://github.com/i-dot-ai/redbox-copilot/assets/227768/2cfa32a7-3bff-4e4e-960f-30c02b6f409d)

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Relevant links


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [x] I have run integration tests
