### PR TITLE
Show route to staff users

### DIFF
--- a/django_app/frontend/style.css
+++ b/django_app/frontend/style.css
@@ -8208,7 +8208,6 @@ body:has(.iai-environment-warning) main {
 .iai-chat-bubble__route {
   font-size: 0.625rem;
   line-height: 0.825rem;
-  display: none;
 }
 
 .iai-chat-bubble__text {

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -93,11 +93,8 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 full_reply.append(await self.handle_text(response))
             elif response.resource_type == "documents":
                 citations += await self.handle_documents(response, user)
-            elif (
-                response.resource_type == "route_name" and user.is_staff
-            ):  # TODO(@rachaelcodes): remove is_staff conditional with new route design
-                # https://technologyprogramme.atlassian.net/browse/REDBOX-419
-                route = await self.handle_route(response)
+            elif response.resource_type == "route_name":
+                route = await self.handle_route(response, user.is_staff)
             elif response.resource_type == "error":
                 raise CoreError(response.data)
         return "".join(full_reply), citations, route
@@ -114,8 +111,11 @@ class ChatConsumer(AsyncWebsocketConsumer):
         await self.send_to_client("text", response.data)
         return response.data
 
-    async def handle_route(self, response: CoreChatResponse) -> str:
-        await self.send_to_client("route", response.data)
+    async def handle_route(self, response: CoreChatResponse, show_route: bool) -> str:
+        # TODO(@rachaelcodes): remove is_staff conditional with new route design
+        # https://technologyprogramme.atlassian.net/browse/REDBOX-419
+        if show_route:
+            await self.send_to_client("route", response.data)
         return response.data
 
     async def send_to_client(self, message_type: str, data: str | Mapping[str, Any] | None = None) -> None:

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -93,7 +93,10 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 full_reply.append(await self.handle_text(response))
             elif response.resource_type == "documents":
                 citations += await self.handle_documents(response, user)
-            elif response.resource_type == "route_name":
+            elif (
+                response.resource_type == "route_name" and user.is_staff
+            ):  # TODO(@rachaelcodes): remove is_staff conditional with new route design
+                # https://technologyprogramme.atlassian.net/browse/REDBOX-419
                 route = await self.handle_route(response)
             elif response.resource_type == "error":
                 raise CoreError(response.data)

--- a/django_app/redbox_app/redbox_core/views.py
+++ b/django_app/redbox_app/redbox_core/views.py
@@ -211,6 +211,9 @@ class ChatsView(View):
     @method_decorator(login_required)
     def get(self, request: HttpRequest, chat_id: uuid.UUID | None = None) -> HttpResponse:
         chat_history = ChatHistory.objects.filter(users=request.user).order_by("-created_at")
+        # TODO(@rachaelcodes): remove this when we have a better route component design
+        # https://technologyprogramme.atlassian.net/browse/REDBOX-419
+        show_route = request.user.is_staff
 
         messages: Sequence[ChatMessage] = []
         if chat_id:
@@ -230,6 +233,7 @@ class ChatsView(View):
             "streaming": {"in_use": settings.USE_STREAMING, "endpoint": str(endpoint)},
             "contact_email": settings.CONTACT_EMAIL,
             "files": all_files,
+            "show_route": show_route,
         }
 
         return render(

--- a/django_app/redbox_app/templates/chats.html
+++ b/django_app/redbox_app/templates/chats.html
@@ -68,7 +68,8 @@
               role = message.role,
               route = message.route,
               text = message.text,
-              citations = message.citation_set.distinct().order_by("file")
+              citations = message.citation_set.distinct().order_by("file"),
+              show_route = show_route
             ) }}
           {% endfor %}
 

--- a/django_app/redbox_app/templates/macros/chat-macros.html
+++ b/django_app/redbox_app/templates/macros/chat-macros.html
@@ -1,4 +1,4 @@
-{% macro message_box(id, role, route, text, citations, classes=None) %}
+{% macro message_box(id, role, route, text, citations, show_route=False, classes=None) %}
 
     {% set role_text = role %}
     {% if role == "ai" %}
@@ -9,7 +9,7 @@
 
     <div class="iai-chat-bubble iai-chat-bubble--{% if role == 'user' %}right{% else %}left{% endif %} js-chat-message govuk-body {{ classes }}" data-role="{{ role }}" tabindex="-1">
         <div class="iai-chat-bubble__role">{% if role == "ai" %}Redbox{% else %}You{% endif %}</div>
-        {% if route %}<div class="iai-chat-bubble__route">{{ route }}</div>{% endif %}
+        {% if route %}<div class="iai-chat-bubble__route {% if not show_route %}govuk-!-display-none{% endif %}">{{ route }}</div>{% endif %}
         <markdown-converter class="iai-chat-bubble__text">{{ text }}</markdown-converter>
         {% if citations %}
             <h3 class="iai-chat-bubble__sources-heading govuk-heading-s govuk-!-margin-bottom-1">Sources</h3>

--- a/django_app/tests/conftest.py
+++ b/django_app/tests/conftest.py
@@ -29,9 +29,9 @@ def _collect_static():
 
 @pytest.fixture()
 def create_user():
-    def _create_user(email, date_joined_iso):
+    def _create_user(email, date_joined_iso, is_staff=False):
         date_joined = datetime.fromisoformat(date_joined_iso).astimezone(UTC)
-        return User.objects.create_user(email=email, date_joined=date_joined)
+        return User.objects.create_user(email=email, date_joined=date_joined, is_staff=is_staff)
 
     return _create_user
 
@@ -66,6 +66,11 @@ def user_with_demographic_data(business_unit: BusinessUnit) -> User:
     return User.objects.create_user(
         email="mrs.tiggywinkle@example.com", grade="DG", business_unit=business_unit, profession="AN"
     )
+
+
+@pytest.fixture()
+def staff_user(create_user):
+    return create_user("staff@example.com", "2000-01-01", True)
 
 
 @pytest.fixture()
@@ -130,13 +135,17 @@ def original_file() -> UploadedFile:
 @pytest.fixture()
 def chat_history_with_files(chat_history: ChatHistory, several_files: Sequence[File]) -> ChatHistory:
     ChatMessage.objects.create(chat_history=chat_history, text="A question?", role=ChatRoleEnum.user)
-    chat_message = ChatMessage.objects.create(chat_history=chat_history, text="An answer.", role=ChatRoleEnum.ai)
+    chat_message = ChatMessage.objects.create(
+        chat_history=chat_history, text="An answer.", role=ChatRoleEnum.ai, route="search"
+    )
     chat_message.source_files.set(several_files[0::2])
     chat_message = ChatMessage.objects.create(
         chat_history=chat_history, text="A second question?", role=ChatRoleEnum.user
     )
     chat_message.selected_files.set(several_files[0:2])
-    chat_message = ChatMessage.objects.create(chat_history=chat_history, text="A second answer.", role=ChatRoleEnum.ai)
+    chat_message = ChatMessage.objects.create(
+        chat_history=chat_history, text="A second answer.", role=ChatRoleEnum.ai, route="search"
+    )
     chat_message.source_files.set([several_files[2]])
     return chat_history
 

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -35,7 +35,42 @@ async def test_chat_consumer_with_new_session(alice: User, uploaded_file: File, 
         response2 = await communicator.receive_json_from(timeout=5)
         response3 = await communicator.receive_json_from(timeout=5)
         response4 = await communicator.receive_json_from(timeout=5)
-        response5 = await communicator.receive_json_from(timeout=5)
+
+        # Then
+        assert response1["type"] == "session-id"
+        assert response2["type"] == "text"
+        assert response2["data"] == "Good afternoon, "
+        assert response3["type"] == "text"
+        assert response3["data"] == "Mr. Amor."
+        assert response4["type"] == "source"
+        assert response4["data"]["original_file_name"] == uploaded_file.original_file_name
+        # Close
+        await communicator.disconnect()
+
+    assert await get_chat_message_text(alice, ChatRoleEnum.user) == ["Hello Hal."]
+    assert await get_chat_message_text(alice, ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
+    assert await get_chat_message_route(alice, ChatRoleEnum.ai) == ["gratitude"]
+    await refresh_from_db(uploaded_file)
+    assert uploaded_file.last_referenced.date() == datetime.now(tz=UTC).date()
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio()
+async def test_chat_consumer_staff_user(staff_user: User, mocked_connect: Connect):
+    # Given
+
+    # When
+    with patch("redbox_app.redbox_core.consumers.connect", new=mocked_connect):
+        communicator = WebsocketCommunicator(ChatConsumer.as_asgi(), "/ws/chat/")
+        communicator.scope["user"] = staff_user
+        connected, _ = await communicator.connect()
+        assert connected
+
+        await communicator.send_json_to({"message": "Hello Hal."})
+        response1 = await communicator.receive_json_from(timeout=5)
+        response2 = await communicator.receive_json_from(timeout=5)
+        response3 = await communicator.receive_json_from(timeout=5)
+        response4 = await communicator.receive_json_from(timeout=5)
 
         # Then
         assert response1["type"] == "session-id"
@@ -45,16 +80,10 @@ async def test_chat_consumer_with_new_session(alice: User, uploaded_file: File, 
         assert response3["data"] == "Mr. Amor."
         assert response4["type"] == "route"
         assert response4["data"] == "gratitude"
-        assert response5["type"] == "source"
-        assert response5["data"]["original_file_name"] == uploaded_file.original_file_name
         # Close
         await communicator.disconnect()
 
-    assert await get_chat_message_text(alice, ChatRoleEnum.user) == ["Hello Hal."]
-    assert await get_chat_message_text(alice, ChatRoleEnum.ai) == ["Good afternoon, Mr. Amor."]
-    assert await get_chat_message_route(alice, ChatRoleEnum.ai) == ["gratitude"]
-    await refresh_from_db(uploaded_file)
-    assert uploaded_file.last_referenced.date() == datetime.now(tz=UTC).date()
+    assert await get_chat_message_route(staff_user, ChatRoleEnum.ai) == ["gratitude"]
 
 
 @pytest.mark.django_db(transaction=True)

--- a/django_app/tests/test_views.py
+++ b/django_app/tests/test_views.py
@@ -396,6 +396,34 @@ def test_user_cannot_see_other_users_citations(chat_message_with_citation: ChatH
     assert response.headers.get("Location") == "/chats/"
 
 
+def test_user_cannot_see_route(chat_history_with_files: ChatHistory, client: Client):
+    # Given
+    client.force_login(chat_history_with_files.users)
+
+    # When
+    response = client.get(f"/chats/{chat_history_with_files.id}/")
+
+    # Then
+    assert response.status_code == HTTPStatus.OK
+    assert b"iai-chat-bubble__route govuk-!-display-none" in response.content
+
+
+@pytest.mark.django_db()
+def test_staff_user_can_see_route(chat_history_with_files: ChatHistory, client: Client):
+    # Given
+    chat_history_with_files.users.is_staff = True
+    chat_history_with_files.users.save()
+    client.force_login(chat_history_with_files.users)
+
+    # When
+    response = client.get(f"/chats/{chat_history_with_files.id}/")
+
+    # Then
+    assert response.status_code == HTTPStatus.OK
+    assert b"iai-chat-bubble__route" in response.content
+    assert b"iai-chat-bubble__route govuk-!-display-none" not in response.content
+
+
 @pytest.mark.django_db()
 def test_check_demographics_redirect_if_unpopulated(client: Client, alice: User):
     # Given

--- a/django_app/tests/test_views.py
+++ b/django_app/tests/test_views.py
@@ -396,6 +396,7 @@ def test_user_cannot_see_other_users_citations(chat_message_with_citation: ChatH
     assert response.headers.get("Location") == "/chats/"
 
 
+@pytest.mark.django_db()
 def test_user_cannot_see_route(chat_history_with_files: ChatHistory, client: Client):
     # Given
     client.force_login(chat_history_with_files.users)


### PR DESCRIPTION
## Context
Some of the AI team have requested that we show the route selected in the front end, but the design is not yet ready for users.

## Changes proposed in this pull request
This shows the route taken by `core_api` but only to staff users.

### View for regular users
<img width="840" alt="regular user" src="https://github.com/i-dot-ai/redbox-copilot/assets/23265724/0bff54d2-4275-4b4c-9b97-c8f6f54d680c">


### View for staff users
<img width="842" alt="staff user" src="https://github.com/i-dot-ai/redbox-copilot/assets/23265724/6250a921-64e2-46aa-afa8-3b39a3c629da">


## Guidance to review
Try this out locally with streamed chats, unstreamed chats and looking back at old chats locally. 
Make sure you run `collectstatic` to update the css and do a hard reset of the page if nothing shows.
Confirm you can see the route with a superuser.
Create a new user in /admin who does not have staff status, log in as them locally and check that you cannot see the route.

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-436

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
