### PR TITLE
Setting embedding retries to 10 and limiting to a single worker to re…

### DIFF
--- a/infrastructure/aws/data.tf
+++ b/infrastructure/aws/data.tf
@@ -46,6 +46,7 @@ locals {
 
   worker_environment_variables = {
     "EMBEDDING_DOCUMENT_FIELD_NAME": var.embedding_document_field_name,
+    "EMBEDDING_MAX_RETRIES": var.embedding_max_retries,
     "ELASTIC_ROOT_INDEX" : "redbox-data-${terraform.workspace}",
     "BUCKET_NAME" : aws_s3_bucket.user_data.bucket,
     "OBJECT_STORE" : "s3",

--- a/infrastructure/aws/ecs.tf
+++ b/infrastructure/aws/ecs.tf
@@ -154,7 +154,7 @@ module "worker" {
   ecs_cluster_id               = module.cluster.ecs_cluster_id
   ecs_cluster_name             = module.cluster.ecs_cluster_name
   autoscaling_minimum_target   = 1
-  autoscaling_maximum_target   = 10
+  autoscaling_maximum_target   = 1
   state_bucket                 = var.state_bucket
   vpc_id                       = data.terraform_remote_state.vpc.outputs.vpc_id
   private_subnets              = data.terraform_remote_state.vpc.outputs.private_subnets

--- a/infrastructure/aws/variables.tf
+++ b/infrastructure/aws/variables.tf
@@ -269,3 +269,9 @@ variable "embedding_document_field_name" {
     default     = "azure_embedding"
     description = "embedding document field name"
 }
+
+variable "embedding_max_retries" {
+  type          = string
+  default       = 10
+  description   = "Number of retries to external embedding services (rate limiting)"
+}


### PR DESCRIPTION
## Context

Full reingest of all files fails due to too many requests to Azure

## Changes proposed in this pull request

Increase number of retries to 10 meaning more files should make it through
Drop max workers to 1, this means we only process three files at once which should further limit the number of requests to Azure

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
