### PR TITLE
Made rate limiting delay on embeddings larger and configurable

### DIFF
--- a/infrastructure/aws/data.tf
+++ b/infrastructure/aws/data.tf
@@ -47,6 +47,8 @@ locals {
   worker_environment_variables = {
     "EMBEDDING_DOCUMENT_FIELD_NAME": var.embedding_document_field_name,
     "EMBEDDING_MAX_RETRIES": var.embedding_max_retries,
+    "EMBEDDING_RETRY_MIN_SECONDS": var.embedding_retry_min_seconds,
+    "EMBEDDING_RETRY_MAX_SECONDS": var.embedding_retry_max_seconds,
     "ELASTIC_ROOT_INDEX" : "redbox-data-${terraform.workspace}",
     "BUCKET_NAME" : aws_s3_bucket.user_data.bucket,
     "OBJECT_STORE" : "s3",

--- a/infrastructure/aws/variables.tf
+++ b/infrastructure/aws/variables.tf
@@ -275,3 +275,15 @@ variable "embedding_max_retries" {
   default       = 10
   description   = "Number of retries to external embedding services (rate limiting)"
 }
+
+variable "embedding_retry_min_seconds" {
+  type          = int
+  default       = 5
+  description   = "Number of seconds to wait before retry to external embedding services (rate limiting)"
+}
+
+variable "embedding_retry_max_seconds" {
+  type          = string
+  default       = 120
+  description   = "Maximum number of seconds to wait before retry to external embedding services (rate limiting)"
+}

--- a/redbox/models/settings.py
+++ b/redbox/models/settings.py
@@ -145,7 +145,9 @@ class Settings(BaseSettings):
     azure_embedding_model: str = "text-embedding-3-large"
     llm_max_tokens: int = 1024
 
-    embedding_max_retries: int = 4
+    embedding_max_retries: int = 10
+    embedding_retry_min_seconds: int = 5
+    embedding_retry_max_seconds: int = 120
     embedding_document_field_name: str = "embedding"
 
     partition_strategy: Literal["auto", "fast", "ocr_only", "hi_res"] = "fast"

--- a/worker/src/app.py
+++ b/worker/src/app.py
@@ -41,8 +41,8 @@ def get_embeddings():
         api_version=env.azure_api_version_embeddings,
         model=env.azure_embedding_model,
         max_retries=env.embedding_max_retries,
-        retry_min_seconds=4,
-        retry_max_seconds=30,
+        retry_min_seconds=env.embedding_retry_min_seconds,
+        retry_max_seconds=env.embedding_retry_max_seconds,
     )
 
 


### PR DESCRIPTION
## Context

We hit rate limiting on embeddings calls really easily. 

## Changes proposed in this pull request

Make all params configurable on the embedding object in the worker and increase the defaults


## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [ ] I have tested any code added or changed
- [ ] I have run integration tests
