### PR TITLE
Track chat routes on Plausible

### DIFF
--- a/django_app/frontend/js/chats/streaming.js
+++ b/django_app/frontend/js/chats/streaming.js
@@ -154,6 +154,12 @@ class ChatMessage extends HTMLElement {
                     route.textContent = message.data;
                     route.removeAttribute("hidden");
                 }
+
+                // send feedback to Plausible
+                let plausible = /** @type {any} */ (window).plausible;
+                if (typeof(plausible) !== 'undefined') {
+                    plausible(`Chat-message-route-${message.data}`);
+                }
             } else if (message.type === 'end') {
                 sourcesContainer.showCitations(message.data.message_id);
             } else if (message.type === 'error') {

--- a/django_app/frontend/js/chats/streaming.js
+++ b/django_app/frontend/js/chats/streaming.js
@@ -158,7 +158,7 @@ class ChatMessage extends HTMLElement {
                 // send route to Plausible
                 let plausible = /** @type {any} */ (window).plausible;
                 if (typeof(plausible) !== 'undefined') {
-                    plausible(`Chat-message-route-${message.data}`);
+                    plausible('Chat-message-route', {props: {route: message.data}});
                 }
             } else if (message.type === 'hidden-route') {
                 // TODO(@rachaelcodes): remove hidden-route with new route design
@@ -167,7 +167,7 @@ class ChatMessage extends HTMLElement {
                 // send route to Plausible
                 let plausible = /** @type {any} */ (window).plausible;
                 if (typeof(plausible) !== 'undefined') {
-                    plausible(`Chat-message-route-${message.data}`);
+                    plausible('Chat-message-route', {props: {route: message.data}});
                 }
             } else if (message.type === 'end') {
                 sourcesContainer.showCitations(message.data.message_id);

--- a/django_app/frontend/js/chats/streaming.js
+++ b/django_app/frontend/js/chats/streaming.js
@@ -155,7 +155,16 @@ class ChatMessage extends HTMLElement {
                     route.removeAttribute("hidden");
                 }
 
-                // send feedback to Plausible
+                // send route to Plausible
+                let plausible = /** @type {any} */ (window).plausible;
+                if (typeof(plausible) !== 'undefined') {
+                    plausible(`Chat-message-route-${message.data}`);
+                }
+            } else if (message.type === 'hidden-route') {
+                // TODO(@rachaelcodes): remove hidden-route with new route design
+                // https://technologyprogramme.atlassian.net/browse/REDBOX-419
+
+                // send route to Plausible
                 let plausible = /** @type {any} */ (window).plausible;
                 if (typeof(plausible) !== 'undefined') {
                     plausible(`Chat-message-route-${message.data}`);

--- a/django_app/frontend/style.css
+++ b/django_app/frontend/style.css
@@ -8433,7 +8433,6 @@ body:has(.iai-environment-warning) main {
 .iai-chat-bubble__route {
   font-size: 0.625rem;
   line-height: 0.825rem;
-  display: none;
 }
 
 .iai-chat-bubble__sources-heading, .iai-chat-bubbles__sources-link {

--- a/django_app/redbox_app/redbox_core/consumers.py
+++ b/django_app/redbox_app/redbox_core/consumers.py
@@ -112,10 +112,12 @@ class ChatConsumer(AsyncWebsocketConsumer):
         return response.data
 
     async def handle_route(self, response: CoreChatResponse, show_route: bool) -> str:
-        # TODO(@rachaelcodes): remove is_staff conditional with new route design
+        # TODO(@rachaelcodes): remove is_staff conditional and hidden-route with new route design
         # https://technologyprogramme.atlassian.net/browse/REDBOX-419
         if show_route:
             await self.send_to_client("route", response.data)
+        else:
+            await self.send_to_client("hidden-route", response.data)
         return response.data
 
     async def send_to_client(self, message_type: str, data: str | Mapping[str, Any] | None = None) -> None:

--- a/django_app/tests/test_consumers.py
+++ b/django_app/tests/test_consumers.py
@@ -35,6 +35,7 @@ async def test_chat_consumer_with_new_session(alice: User, uploaded_file: File, 
         response2 = await communicator.receive_json_from(timeout=5)
         response3 = await communicator.receive_json_from(timeout=5)
         response4 = await communicator.receive_json_from(timeout=5)
+        response5 = await communicator.receive_json_from(timeout=5)
 
         # Then
         assert response1["type"] == "session-id"
@@ -42,8 +43,10 @@ async def test_chat_consumer_with_new_session(alice: User, uploaded_file: File, 
         assert response2["data"] == "Good afternoon, "
         assert response3["type"] == "text"
         assert response3["data"] == "Mr. Amor."
-        assert response4["type"] == "source"
-        assert response4["data"]["original_file_name"] == uploaded_file.original_file_name
+        assert response4["type"] == "hidden-route"
+        assert response4["data"] == "gratitude"
+        assert response5["type"] == "source"
+        assert response5["data"]["original_file_name"] == uploaded_file.original_file_name
         # Close
         await communicator.disconnect()
 


### PR DESCRIPTION
## Context
This allows us to track the route used in a chat message on Plausible in streamed chat.

## Changes proposed in this pull request
Sends the route to the JS app for non-staff users in a new 'hidden-route' event type (this can be removed when the route is available to all users).

For both the 'route' and 'hidden-route' event types, trigger a custom `Chat-message-route-[ROUTE NAME]` event in Plausible: 
https://plausible.io/docs/custom-event-goals#trigger-custom-events-manually-with-a-javascript-function

## Guidance to review
- For someone with experience with Plausible (@KevinEtchells) : Does this look like it will work?
- Does the code run locally (without Plausible) without triggering console errors? 

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-439
https://plausible.io/docs/custom-event-goals#trigger-custom-events-manually-with-a-javascript-function

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
