### PR TITLE
New core-api PUT endpoint for file reingestion

### DIFF
--- a/core_api/tests/routes/test_file.py
+++ b/core_api/tests/routes/test_file.py
@@ -108,6 +108,24 @@ def test_delete_missing_file(app_client, headers):
     assert response.status_code == HTTPStatus.NOT_FOUND
 
 
+def test_reingest_file(app_client, chunked_file, elasticsearch_storage_handler, headers):
+    """
+    Given a previously chunked file
+    When I PUT it to /file/uuid/
+    I Expect the old chunks to be removed
+    """
+    previous_chunks = elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid, chunked_file.creator_user_uuid)
+
+    response = app_client.put(f"/file/{chunked_file.uuid}", headers=headers)
+    assert response.status_code == HTTPStatus.OK
+
+    elasticsearch_storage_handler.refresh()
+    assert (
+        elasticsearch_storage_handler.get_file_chunks(chunked_file.uuid, chunked_file.creator_user_uuid)
+        != previous_chunks
+    )
+
+
 def test_get_file_chunks(app_client, chunked_file, headers):
     """
     Given a previously chunked file

--- a/django_app/redbox_app/redbox_core/client.py
+++ b/django_app/redbox_app/redbox_core/client.py
@@ -114,3 +114,9 @@ class CoreApiClient:
         response = requests.delete(url, headers={"Authorization": user.get_bearer_token()}, timeout=60)
         response.raise_for_status()
         return FileOperation.schema().loads(response.content)
+
+    def reingest_file(self, file_id: UUID, user: User) -> FileOperation:
+        url = self.url / "file" / str(file_id)
+        response = requests.put(url, headers={"Authorization": user.get_bearer_token()}, timeout=60)
+        response.raise_for_status()
+        return FileOperation.schema().loads(response.content)


### PR DESCRIPTION
## Context
The previous attempt to reingest files via Djano admin would time out. This replaces the slower core-api request with a new API call that triggers jobs asynchronously.

## Changes proposed in this pull request
Adds and tests a new PUT endpoint for /file that triggers a re-ingestion. 
Updates the Django Admin reingestion task to use this. 

## Guidance to review
Run locally by going to admin, selecting files and the 'Reupload' action.

You can also prompt an error for some documents by changing the core-api-uuid in admin before running the admin task and confirm that the rest of the files update as expected.

At the moment, we don't show Errored documents to the user in the documents page. Perhaps we should?

## Relevant links
https://technologyprogramme.atlassian.net/browse/REDBOX-445

## Things to check

- [ ] I have added any new ENV vars in all deployed environments
- [x] I have tested any code added or changed
- [ ] I have run integration tests
